### PR TITLE
event based chain syncing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,7 +2531,7 @@ dependencies = [
  "parity-scale-codec 2.1.1",
  "polkadex-fungible-assets",
  "polkadex-ocex",
- "polkadex-primitives",
+ "polkadex-primitives 0.1.0 (git+https://github.com/Polkadex-Substrate/Polkadex?branch=develop)",
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
@@ -3277,7 +3277,7 @@ dependencies = [
  "orml-traits",
  "pallet-balances",
  "parity-scale-codec 2.1.1",
- "polkadex-primitives",
+ "polkadex-primitives 0.1.0 (git+https://github.com/Polkadex-Substrate/Polkadex?branch=develop)",
  "rustc-hex",
  "serde",
  "sp-core",
@@ -3300,12 +3300,23 @@ dependencies = [
  "pallet-substratee-registry",
  "pallet-timestamp",
  "parity-scale-codec 2.1.1",
- "polkadex-primitives",
+ "polkadex-primitives 0.1.0 (git+https://github.com/Polkadex-Substrate/Polkadex?branch=develop)",
  "rustc-hex",
  "serde",
  "sp-core",
  "sp-io 3.0.0",
  "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "polkadex-primitives"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "parity-scale-codec 2.1.1",
+ "sgx_tstd",
+ "sp-core",
  "sp-std",
 ]
 
@@ -5389,6 +5400,7 @@ dependencies = [
  "node-polkadex-runtime",
  "pallet-balances",
  "parity-scale-codec 2.1.1",
+ "polkadex-primitives 0.1.0",
  "primitive-types 0.9.0",
  "rust-crypto",
  "serde",

--- a/enclave/Enclave.edl
+++ b/enclave/Enclave.edl
@@ -50,7 +50,7 @@ enclave {
             [in, size=pdex_accounts_size] uint8_t* pdex_accounts, size_t pdex_accounts_size
         );
 
-        public sgx_status_t produce_blocks(
+        public sgx_status_t sync_chain(
             [in, size=blocks_size] uint8_t* blocks, size_t blocks_size,
             [in] uint32_t* nonce
         );

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -381,7 +381,7 @@ pub unsafe extern "C" fn accept_pdex_accounts(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn produce_blocks(
+pub unsafe extern "C" fn sync_chain(
     blocks_to_sync: *const u8,
     blocks_to_sync_size: usize,
     nonce: *const u32,

--- a/polkadex-primitives/src/lib.rs
+++ b/polkadex-primitives/src/lib.rs
@@ -19,6 +19,7 @@ pub struct LinkedAccount {
     pub proxies: Vec<AccountId>
 }
 
+
 #[derive(Encode, Decode, Clone, Debug, PartialEq)]
 pub struct PolkadexAccount {
     pub account: LinkedAccount,

--- a/worker/src/enclave/api.rs
+++ b/worker/src/enclave/api.rs
@@ -65,7 +65,7 @@ extern "C" {
         pdex_accounts_size: usize,
     ) -> sgx_status_t;
 
-    fn produce_blocks(
+    fn sync_chain(
         eid: sgx_enclave_id_t,
         retval: *mut sgx_status_t,
         blocks: *const u8,
@@ -267,7 +267,7 @@ pub fn enclave_accept_pdex_accounts(
 /// Starts block production within enclave
 ///
 /// Returns the produced blocks
-pub fn enclave_produce_blocks(
+pub fn enclave_sync_chain(
     eid: sgx_enclave_id_t,
     blocks_to_sync: Vec<SignedBlock>,
     tee_nonce: u32,
@@ -276,7 +276,7 @@ pub fn enclave_produce_blocks(
 
     let result = unsafe {
         blocks_to_sync
-            .using_encoded(|b| produce_blocks(eid, &mut status, b.as_ptr(), b.len(), &tee_nonce))
+            .using_encoded(|b| sync_chain(eid, &mut status, b.as_ptr(), b.len(), &tee_nonce))
     };
 
     if status != sgx_status_t::SGX_SUCCESS {

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -523,10 +523,9 @@ pub fn init_chain_relay(eid: sgx_enclave_id_t, api: &Api<sr25519::Pair>) -> Head
 
     info!("Finished initializing chain relay, syncing....");
 
-    //FIXME: These are currently failing. There seems to be a problem with the OCEX pallet
-    /* let polkadex_accounts: Vec<PolkadexAccount> = polkadex::get_main_accounts(latest.clone(), api);
+    let polkadex_accounts: Vec<PolkadexAccount> = polkadex::get_main_accounts(latest.clone(), api);
 
-    enclave_accept_pdex_accounts(eid,polkadex_accounts).unwrap(); */
+    enclave_accept_pdex_accounts(eid,polkadex_accounts).unwrap();
 
     info!("Finishing retrieving Polkadex Accounts, ...");
 

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -523,9 +523,10 @@ pub fn init_chain_relay(eid: sgx_enclave_id_t, api: &Api<sr25519::Pair>) -> Head
 
     info!("Finished initializing chain relay, syncing....");
 
-    //let polkadex_accounts: Vec<PolkadexAccount> = polkadex::get_main_accounts(latest.clone(), api);
+    //FIXME: These are currently failing. There seems to be a problem with the OCEX pallet
+    /* let polkadex_accounts: Vec<PolkadexAccount> = polkadex::get_main_accounts(latest.clone(), api);
 
-    //enclave_accept_pdex_accounts(eid,polkadex_accounts).unwrap();
+    enclave_accept_pdex_accounts(eid,polkadex_accounts).unwrap(); */
 
     info!("Finishing retrieving Polkadex Accounts, ...");
 

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -25,7 +25,7 @@ use std::sync::{
     Mutex,
 };
 use std::thread;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration};
 
 use base58::{FromBase58, ToBase58};
 use clap::{App, load_yaml};
@@ -66,8 +66,6 @@ mod polkadex;
 /// how many blocks will be synced before storing the chain db to disk
 const BLOCK_SYNC_BATCH_SIZE: u32 = 1000;
 const VERSION: &str = env!("CARGO_PKG_VERSION");
-/// start block production every ... ms
-const BLOCK_PRODUCTION_INTERVAL: u64 = 1000;
 
 fn main() {
     // Setup logging

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -336,16 +336,8 @@ fn worker(
         println!("[<] Extrinsic got finalized. Hash: {:?}\n", tx_hash);
     }
 
-    let latest_head = init_chain_relay(eid, &api);
+    let mut latest_head = init_chain_relay(eid, &api);
     println!("*** [+] Finished syncing chain relay\n");
-
-    // ------------------------------------------------------------------------
-    // start interval block production
-    let api4 = api.clone();
-    thread::Builder::new()
-        .name("interval_block_production_timer".to_owned())
-        .spawn(move || start_interval_block_production(eid, &api4, latest_head))
-        .unwrap();
 
     // ------------------------------------------------------------------------
     // subscribe to events and react on firing
@@ -360,7 +352,7 @@ fn worker(
         })
         .unwrap();
 
-    let api3 = api;
+    let api3 = api.clone();
     let sender3 = sender.clone();
     let _block_subscriber = thread::Builder::new()
         .name("block_subscriber".to_owned())
@@ -373,29 +365,8 @@ fn worker(
         if let Ok(msg) = receiver.recv_timeout(timeout) {
             if let Ok(events) = parse_events(msg.clone()) {
                 print_events(events, sender.clone())
-            }
-        }
-    }
-}
-
-/// Triggers the enclave to produce a block based on a fixed time schedule
-fn start_interval_block_production(
-    eid: sgx_enclave_id_t,
-    api: &Api<sr25519::Pair>,
-    mut latest_head: Header,
-) {
-    let block_production_interval = Duration::from_millis(BLOCK_PRODUCTION_INTERVAL);
-    let mut interval_start = SystemTime::now();
-    loop {
-        if let Ok(elapsed) = interval_start.elapsed() {
-            if elapsed >= block_production_interval {
-                // update interval time
-                interval_start = SystemTime::now();
-                latest_head = sync_chain(eid, api, latest_head)
-            } else {
-                // sleep for the rest of the interval
-                let sleep_time = block_production_interval - elapsed;
-                thread::sleep(sleep_time);
+            } else if let Ok(_header) = parse_header(msg.clone()) {
+                latest_head = sync_chain(eid, &api, latest_head)
             }
         }
     }
@@ -433,6 +404,10 @@ fn parse_events(event: String) -> Result<Events, String> {
     let _unhex = Vec::from_hex(event).map_err(|_| "Decoding Events Failed".to_string())?;
     let mut _er_enc = _unhex.as_slice();
     Events::decode(&mut _er_enc).map_err(|_| "Decoding Events Failed".to_string())
+}
+
+fn parse_header(header: String) -> Result<Header, String> {
+    serde_json::from_str(&header).map_err(|_| "Decoding Header Failed".to_string())
 }
 
 fn print_events(events: Events, _sender: Sender<String>) {
@@ -481,6 +456,7 @@ fn print_events(events: Events, _sender: Sender<String>) {
                         debug!("    From:    {:?}", sender);
                         debug!("    Payload: {:?}", hex::encode(payload));
                     }
+                    //FIXME: BlockConfirmed still necessary for Polkadex?
                     my_node_runtime::pallet_substratee_registry::RawEvent::BlockConfirmed(
                         sender,
                         payload,
@@ -547,9 +523,9 @@ pub fn init_chain_relay(eid: sgx_enclave_id_t, api: &Api<sr25519::Pair>) -> Head
 
     info!("Finished initializing chain relay, syncing....");
 
-    let polkadex_accounts: Vec<PolkadexAccount> = polkadex::get_main_accounts(latest.clone(), api);
+    //let polkadex_accounts: Vec<PolkadexAccount> = polkadex::get_main_accounts(latest.clone(), api);
 
-    enclave_accept_pdex_accounts(eid,polkadex_accounts).unwrap();
+    //enclave_accept_pdex_accounts(eid,polkadex_accounts).unwrap();
 
     info!("Finishing retrieving Polkadex Accounts, ...");
 
@@ -573,14 +549,17 @@ pub fn sync_chain(
         .unwrap()
         .unwrap();
 
-    let mut blocks_to_sync = Vec::<SignedBlock>::new();
+        if curr_head.block.header.hash() == last_synced_head.hash() {
+            // we are already up to date, do nothing
+            return curr_head.block.header;
+        }
 
-    // add blocks to sync if not already up to date
-    if curr_head.block.header.hash() != last_synced_head.hash() {
+        let mut blocks_to_sync = Vec::<SignedBlock>::new();
         blocks_to_sync.push(curr_head.clone());
 
         // Todo: Check, is this dangerous such that it could be an eternal or too big loop?
         let mut head = curr_head.clone();
+
         let no_blocks_to_sync = head.block.header.number - last_synced_head.number;
         if no_blocks_to_sync > 1 {
             println!(
@@ -592,8 +571,8 @@ pub fn sync_chain(
                 head.block.header.number
             );
         }
+
         while head.block.header.parent_hash != last_synced_head.hash() {
-            debug!("Getting head of hash: {:?}", head.block.header.parent_hash);
             head = api
                 .get_signed_block(Some(head.block.header.parent_hash))
                 .unwrap()
@@ -608,33 +587,30 @@ pub fn sync_chain(
             }
         }
         blocks_to_sync.reverse();
-    }
 
-    let tee_accountid = enclave_account(eid);
+        let tee_accountid = enclave_account(eid);
 
-    // only feed BLOCK_SYNC_BATCH_SIZE blocks at a time into the enclave to save enclave state regularly
-    let mut i = if curr_head.block.header.hash() == last_synced_head.hash() {
-        curr_head.block.header.number as usize
-    } else {
-        blocks_to_sync[0].block.header.number as usize
-    };
-    for chunk in blocks_to_sync.chunks(BLOCK_SYNC_BATCH_SIZE as usize) {
-        let tee_nonce = get_nonce(&api, &tee_accountid);
-        // Produce blocks
-        if let Err(e) = enclave_sync_chain(eid, chunk.to_vec(), tee_nonce) {
-            error!("{}", e);
-            // enclave might not have synced
-            return last_synced_head;
-        };
-        i += chunk.len();
-        println!(
-            "Synced {} blocks out of {} finalized blocks",
-            i,
-            blocks_to_sync[0].block.header.number as usize + blocks_to_sync.len()
-        )
-    }
+        // only feed BLOCK_SYNC_BATCH_SIZE blocks at a time into the enclave to save enclave state regularly
+        let mut i = blocks_to_sync[0].block.header.number as usize;
+        for chunk in blocks_to_sync.chunks(BLOCK_SYNC_BATCH_SIZE as usize) {
+            let tee_nonce = get_nonce(&api, &tee_accountid);
 
-    curr_head.block.header
+            // sync enclave with chain
+            if let Err(e) = enclave_sync_chain(eid, chunk.to_vec(), tee_nonce) {
+                error!("{}", e);
+                // enclave might not have synced
+                return last_synced_head;
+            };
+
+            i += chunk.len();
+            println!(
+                "Synced {} blocks out of {} finalized blocks",
+                i,
+                blocks_to_sync[0].block.header.number as usize + blocks_to_sync.len()
+            )
+        }
+
+        curr_head.block.header
 }
 
 fn hex_encode(data: Vec<u8>) -> String {

--- a/worker/src/polkadex.rs
+++ b/worker/src/polkadex.rs
@@ -33,13 +33,13 @@ pub fn get_storage_and_proof(
     api: &Api<sr25519::Pair>,
 ) -> PolkadexAccount {
     let last_acc: LinkedAccount = api
-        .get_storage_map("OCEX", "MainAccounts", acc.clone(), Some(header.hash()))
+        .get_storage_map("PolkadexOcex", "MainAccounts", acc.clone(), Some(header.hash()))
         .unwrap()
         .map(|account: LinkedAccount| account.into())
         .unwrap();
 
     let last_acc_proof: Vec<Vec<u8>> = api.get_storage_map_proof::<AccountId,LinkedAccount>(
-        "OCEX",
+        "PolkadexOcex",
         "MainAccounts",
         acc,
         Some(header.hash()))

--- a/worker/src/tests/integration_tests.rs
+++ b/worker/src/tests/integration_tests.rs
@@ -72,7 +72,7 @@ pub fn call_worker_encrypted_set_balance_works(
     println!("Sleeping until block with shield funds is finalized...");
     sleep(Duration::new(10, 0));
     println!("Syncing Chain Relay to look for shield_funds extrinsic");
-    crate::produce_blocks(eid, &api, last_synced_head)
+    crate::sync_chain(eid, &api, last_synced_head)
 }
 pub fn forward_encrypted_unshield_works(
     eid: sgx_enclave_id_t,
@@ -94,7 +94,7 @@ pub fn forward_encrypted_unshield_works(
     println!("Sleeping until block with shield funds is finalized...");
     sleep(Duration::new(10, 0));
     println!("Syncing Chain Relay to look for CallWorker with TrustedCall::unshield extrinsic");
-    crate::produce_blocks(eid, &api, last_synced_head)
+    crate::sync_chain(eid, &api, last_synced_head)
 }
 
 pub fn init_chain_relay(eid: sgx_enclave_id_t, port: &str) -> Header {
@@ -121,5 +121,5 @@ pub fn shield_funds_workds(eid: sgx_enclave_id_t, port: &str, last_synced_head: 
     println!("Sleeping until block with shield funds is finalized...");
     sleep(Duration::new(10, 0));
     println!("Syncing Chain Relay to look for shield_funds extrinsic");
-    crate::produce_blocks(eid, &api, last_synced_head)
+    crate::sync_chain(eid, &api, last_synced_head)
 }


### PR DESCRIPTION
Syncs the chain whenever a finalized block event is detected instead of time interval based syncing.
closes #16

Sidenote: To worker currently fails to read the polkadex accounts. Hence, to test this PR it's necessary to comment these two lines: https://github.com/Polkadex-Substrate/polkadexTEE-worker/blob/16/event-based-chain-sync/worker/src/main.rs#L524-L526