### PR TITLE
Fix broken untrusted CLI calls in client

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -123,7 +123,7 @@ fn main() {
             Command::new("new-account")
                 .description("generates a new account for the substraTEE chain")
                 .runner(|_args: &str, matches: &ArgMatches<'_>| {
-                    let store = LocalKeystore::open(get_keystore_path(matches), None).unwrap();
+                    let store = LocalKeystore::open(get_untrusted_keystore_path(), None).unwrap();
                     let key: sr25519::AppPair = store.generate().unwrap();
                     drop(store);
                     println!("{}", key.public().to_ss58check());
@@ -134,7 +134,7 @@ fn main() {
             Command::new("list-accounts")
                 .description("lists all accounts in keystore for the substraTEE chain")
                 .runner(|_args: &str, matches: &ArgMatches<'_>| {
-                    let store = LocalKeystore::open(get_keystore_path(matches), None).unwrap();
+                    let store = LocalKeystore::open(get_untrusted_keystore_path(), None).unwrap();
                     println!("sr25519 keys:");
                     for pubkey in store
                         .public_keys::<sr25519::AppPublic>()
@@ -268,7 +268,7 @@ fn main() {
                     let arg_to = matches.value_of("to").unwrap();
                     let amount = u128::from_str_radix(matches.value_of("amount").unwrap(), 10)
                         .expect("amount can be converted to u128");
-                    let from = get_pair_from_str(matches,arg_from);
+                    let from = get_pair_from_str_untrusted(arg_from);
                     let to = get_accountid_from_str(arg_to);
                     info!("from ss58 is {}", from.public().to_ss58check());
                     info!("to ss58 is {}", to.to_ss58check());
@@ -386,7 +386,7 @@ fn main() {
 
                     // get the sender
                     let arg_from = matches.value_of("from").unwrap();
-                    let from = get_pair_from_str(matches, arg_from);
+                    let from = get_pair_from_str_untrusted( arg_from);
                     let chain_api = chain_api.set_signer(sr25519_core::Pair::from(from));
 
                     // get the recipient
@@ -540,7 +540,9 @@ fn send_request(matches: &ArgMatches<'_>, call: TrustedCallSigned) -> Option<Vec
     let shard = read_shard(matches).unwrap();
 
     let arg_signer = matches.value_of("xt-signer").unwrap();
-    let signer = get_pair_from_str(matches, arg_signer);
+
+    // TODO: clarify: we're getting these account information from the untrusted key store, is that correct?
+    let signer = get_pair_from_str_untrusted(arg_signer);
     let _chain_api = chain_api.set_signer(sr25519_core::Pair::from(signer));
 
     let request = Request {

--- a/stf/src/cli.rs
+++ b/stf/src/cli.rs
@@ -87,7 +87,8 @@ pub fn cmd(perform_operation: OperationRunner) -> MultiCommand<str, str> {
             Command::new("new-account")
                 .description("generates a new incognito account for the given substraTEE shard")
                 .runner(|_args: &str, matches: &ArgMatches<'_>| {
-                    let store = LocalKeystore::open(get_keystore_path(matches), None).unwrap();
+                    let store =
+                        LocalKeystore::open(get_trusted_keystore_path(matches), None).unwrap();
                     let key: sr25519::AppPair = store.generate().unwrap();
                     drop(store);
                     println!("{}", key.public().to_ss58check());
@@ -98,7 +99,8 @@ pub fn cmd(perform_operation: OperationRunner) -> MultiCommand<str, str> {
             Command::new("list-accounts")
                 .description("lists all accounts in keystore for the substraTEE chain")
                 .runner(|_args: &str, matches: &ArgMatches<'_>| {
-                    let store = LocalKeystore::open(get_keystore_path(matches), None).unwrap();
+                    let store =
+                        LocalKeystore::open(get_trusted_keystore_path(matches), None).unwrap();
                     info!("sr25519 keys:");
                     for pubkey in store
                         .public_keys::<sr25519::AppPublic>()
@@ -151,7 +153,7 @@ pub fn cmd(perform_operation: OperationRunner) -> MultiCommand<str, str> {
                     let arg_to = matches.value_of("to").unwrap();
                     let amount = u128::from_str_radix(matches.value_of("amount").unwrap(), 10)
                         .expect("amount can be converted to u128");
-                    let from = get_pair_from_str(matches, arg_from);
+                    let from = get_pair_from_str_trusted(matches, arg_from);
                     let to = get_accountid_from_str(arg_to);
                     let direct: bool = matches.is_present("direct");
                     info!("from ss58 is {}", from.public().to_ss58check());
@@ -201,8 +203,8 @@ pub fn cmd(perform_operation: OperationRunner) -> MultiCommand<str, str> {
                     let arg_who = matches.value_of("account").unwrap();
                     let amount = u128::from_str_radix(matches.value_of("amount").unwrap(), 10)
                         .expect("amount can be converted to u128");
-                    let who = get_pair_from_str(matches, arg_who);
-                    let signer = get_pair_from_str(matches, "//Alice");
+                    let who = get_pair_from_str_trusted(matches, arg_who);
+                    let signer = get_pair_from_str_trusted(matches, "//Alice");
                     let direct: bool = matches.is_present("direct");
                     info!("account ss58 is {}", who.public().to_ss58check());
 
@@ -243,7 +245,7 @@ pub fn cmd(perform_operation: OperationRunner) -> MultiCommand<str, str> {
                 .runner(move |_args: &str, matches: &ArgMatches<'_>| {
                     let arg_who = matches.value_of("accountid").unwrap();
                     info!("arg_who = {:?}", arg_who);
-                    let who = get_pair_from_str(matches, arg_who);
+                    let who = get_pair_from_str_trusted(matches, arg_who);
                     let key_pair = sr25519_core::Pair::from(who.clone());
                     let top: TrustedOperation = TrustedGetter::free_balance(
                         sr25519_core::Public::from(who.public()).into(),
@@ -303,7 +305,7 @@ pub fn cmd(perform_operation: OperationRunner) -> MultiCommand<str, str> {
                     let arg_to = matches.value_of("to").unwrap();
                     let amount = u128::from_str_radix(matches.value_of("amount").unwrap(), 10)
                         .expect("amount can be converted to u128");
-                    let from = get_pair_from_str(matches, arg_from);
+                    let from = get_pair_from_str_trusted(matches, arg_from);
                     let to = get_accountid_from_str(arg_to);
                     let direct: bool = matches.is_present("direct");
                     println!("from ss58 is {}", from.public().to_ss58check());

--- a/stf/src/commands/account_details.rs
+++ b/stf/src/commands/account_details.rs
@@ -90,16 +90,19 @@ mod tests {
         add_main_account_args, add_proxy_account_args, ACCOUNT_ID_ARG_NAME,
         PROXY_ACCOUNT_ID_ARG_NAME,
     };
+    use crate::commands::test_utils::utils::{add_identifiers_app_args, create_identifier_args};
     use clap::{App, AppSettings};
 
     #[test]
     fn given_proxy_account_argument_then_account_details_has_some() {
         let main_account_arg = format!("--{}=//main_ojwf8a", ACCOUNT_ID_ARG_NAME);
         let proxy_account_arg = format!("--{}=//proxy_awf43t", PROXY_ACCOUNT_ID_ARG_NAME);
+        let mut matches_args = vec![main_account_arg, proxy_account_arg];
+        matches_args.append(&mut create_identifier_args());
 
         let test_app = create_test_app();
 
-        let matches = test_app.get_matches_from(vec![main_account_arg, proxy_account_arg]);
+        let matches = test_app.get_matches_from(matches_args);
 
         let account_details = AccountDetails::new(&matches);
 
@@ -123,10 +126,12 @@ mod tests {
     #[test]
     fn given_no_proxy_account_argument_then_account_details_has_none() {
         let main_account_arg = format!("--{}=//main_ojwf8a", ACCOUNT_ID_ARG_NAME);
+        let mut matches_args = vec![main_account_arg];
+        matches_args.append(&mut create_identifier_args());
 
         let test_app = create_test_app();
 
-        let matches = test_app.get_matches_from(vec![main_account_arg]);
+        let matches = test_app.get_matches_from(matches_args);
 
         let account_details = AccountDetails::new(&matches);
 
@@ -147,7 +152,8 @@ mod tests {
 
         let app_with_main_account = add_main_account_args(test_app);
         let app_with_proxy_account = add_proxy_account_args(app_with_main_account);
+        let app_with_identifiers = add_identifiers_app_args(app_with_proxy_account);
 
-        app_with_proxy_account
+        app_with_identifiers
     }
 }

--- a/stf/src/commands/account_details.rs
+++ b/stf/src/commands/account_details.rs
@@ -15,7 +15,7 @@
 
 */
 
-use crate::cli_utils::account_parsing::get_pair_from_str;
+use crate::cli_utils::account_parsing::get_pair_from_str_trusted;
 use crate::commands::common_args::{ACCOUNT_ID_ARG_NAME, PROXY_ACCOUNT_ID_ARG_NAME};
 use clap::ArgMatches;
 use sp_application_crypto::sr25519;
@@ -36,10 +36,11 @@ impl AccountDetails {
             ACCOUNT_ID_ARG_NAME
         ));
 
-        let main_account_pair = get_pair_from_str(matches, arg_account);
+        let main_account_pair = get_pair_from_str_trusted(matches, arg_account);
 
         let arg_proxy_account_option = matches.value_of(PROXY_ACCOUNT_ID_ARG_NAME);
-        let proxy_account_pair = arg_proxy_account_option.map(|pa| get_pair_from_str(matches, pa));
+        let proxy_account_pair =
+            arg_proxy_account_option.map(|pa| get_pair_from_str_trusted(matches, pa));
 
         AccountDetails {
             main_account: main_account_pair,


### PR DESCRIPTION
Fix untrusted calls in client that tried to use trusted keystore instead of untrusted one

This was introduced in a previous refactoring, as part of
https://github.com/Polkadex-Substrate/polkadexTEE-worker/pull/30

Resolves #82