### PR TITLE
Ocex client calls

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -417,6 +417,7 @@ fn main() {
         .add_cmd(ocex_commands::register_proxy_command())
         .add_cmd(ocex_commands::remove_proxy_command())
         .add_cmd(ocex_commands::withdraw_command())
+        .add_cmd(ocex_commands::deposit_command())
         .add_cmd(substratee_stf::cli::cmd(&perform_trusted_operation))
         .no_cmd(|_args, _matches| {
             println!("No subcommand matched");

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -416,6 +416,7 @@ fn main() {
         .add_cmd(ocex_commands::register_account_command())
         .add_cmd(ocex_commands::register_proxy_command())
         .add_cmd(ocex_commands::remove_proxy_command())
+        .add_cmd(ocex_commands::withdraw_command())
         .add_cmd(substratee_stf::cli::cmd(&perform_trusted_operation))
         .no_cmd(|_args, _matches| {
             println!("No subcommand matched");

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -23,6 +23,8 @@ extern crate clap;
 extern crate env_logger;
 extern crate log;
 
+mod ocex_commands;
+
 extern crate chrono;
 use chrono::{DateTime, Utc};
 
@@ -411,42 +413,7 @@ fn main() {
                     Ok(())
                 }),
         )
-        .add_cmd(
-            Command::new("register-account")
-                .description("Registers a new main account to the polkadex offchain registry")
-                .options(|app| {
-                    app.arg(
-                        Arg::with_name("from")
-                            .takes_value(true)
-                            .required(true)
-                            .value_name("SS58")
-                            .help("Sender's on-chain AccountId in ss58check format"),
-                    )
-                })
-                .runner(move |_args: &str, matches: &ArgMatches<'_>| {
-                    let chain_api = get_chain_api(matches);
-
-                    // get the sender
-                    let arg_from = matches.value_of("from").unwrap();
-                    let from = get_pair_from_str(matches, arg_from);
-                    let account_id = sr25519_core::Pair::from(from);
-                    let chain_api = chain_api.set_signer(account_id.clone());
-
-                    // compose the extrinsic
-                    let xt: UncheckedExtrinsicV4<([u8; 2], AccountId)> = compose_extrinsic!(
-                        chain_api,
-                        "PolkadexOcex",
-                        "register",
-                        account_id.public().into()
-                    );
-
-                    let tx_hash = chain_api
-                        .send_extrinsic(xt.hex_encode(), XtStatus::Finalized)
-                        .unwrap();
-                    println!("[+] TrustedOperation got finalized. Hash: {:?}\n", tx_hash);
-                    Ok(())
-                }),
-        )
+        .add_cmd(ocex_commands::register_account_command())
         .add_cmd(substratee_stf::cli::cmd(&perform_trusted_operation))
         .no_cmd(|_args, _matches| {
             println!("No subcommand matched");

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -414,6 +414,7 @@ fn main() {
                 }),
         )
         .add_cmd(ocex_commands::register_account_command())
+        .add_cmd(ocex_commands::register_proxy_command())
         .add_cmd(substratee_stf::cli::cmd(&perform_trusted_operation))
         .no_cmd(|_args, _matches| {
             println!("No subcommand matched");

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -415,6 +415,7 @@ fn main() {
         )
         .add_cmd(ocex_commands::register_account_command())
         .add_cmd(ocex_commands::register_proxy_command())
+        .add_cmd(ocex_commands::remove_proxy_command())
         .add_cmd(substratee_stf::cli::cmd(&perform_trusted_operation))
         .no_cmd(|_args, _matches| {
             println!("No subcommand matched");

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -456,6 +456,7 @@ fn perform_trusted_operation(matches: &ArgMatches<'_>, top: &TrustedOperation) -
     }
 }
 
+#[allow(unused)]
 fn get_state(matches: &ArgMatches<'_>, getter: TrustedOperation) -> Option<Vec<u8>> {
     // TODO: ensure getter is signed?
     let (_operation_call_encoded, operation_call_encrypted) = match encode_encrypt(matches, getter)
@@ -645,6 +646,7 @@ fn send_direct_request_encoded(
 }
 
 /// sends a rpc watch request to the worker api server
+#[allow(unused)]
 fn send_direct_request_encrypted(
     matches: &ArgMatches<'_>,
     operation_call: TrustedOperation,

--- a/client/src/ocex_commands.rs
+++ b/client/src/ocex_commands.rs
@@ -1,36 +1,16 @@
 use log::*;
 
-use base58::{FromBase58, ToBase58};
-use clap::{AppSettings, Arg, ArgMatches, App};
-use clap_nested::{Command, Commander};
-use codec::{Decode, Encode};
-use log::*;
-use my_node_runtime::{
-    pallet_substratee_registry::{Enclave, Request},
-    AccountId, BalancesCall, Call, Event, Hash,
-};
-use polkadex_sgx_primitives::{AssetId, PolkadexAccount, Balance};
-use polkadex_sgx_primitives::types::DirectRequest;
-use sgx_crypto_helper::rsa3072::Rsa3072PubKey;
-use sp_application_crypto::{ed25519, sr25519};
-use sp_core::{crypto::Ss58Codec, sr25519 as sr25519_core, Pair, H256};
-use sp_keyring::AccountKeyring;
-use sp_runtime::MultiSignature;
-use std::convert::TryFrom;
-use std::result::Result as StdResult;
-use std::sync::mpsc::channel;
-use std::thread;
-use std::time::{Duration, UNIX_EPOCH};
+use clap::{Arg, ArgMatches, App};
+use clap_nested::Command;
+use my_node_runtime::AccountId;
+use polkadex_sgx_primitives::{AssetId, Balance};
+use sp_core::{sr25519 as sr25519_core, Pair};
 use substrate_api_client::{
-    compose_extrinsic, compose_extrinsic_offline,
-    events::EventsDecoder,
-    extrinsic::xt_primitives::{GenericAddress, UncheckedExtrinsicV4},
-    node_metadata::Metadata,
-    utils::FromHexString,
-    Api, XtStatus,
+    compose_extrinsic,
+    extrinsic::xt_primitives::UncheckedExtrinsicV4,
+    XtStatus,
 };
 
-use substratee_stf::commands;
 use substratee_stf::commands::{common_args_processing, common_args};
 
 pub fn register_account_command<'a>() -> Command<'a, str> {

--- a/client/src/ocex_commands.rs
+++ b/client/src/ocex_commands.rs
@@ -49,21 +49,20 @@ pub fn register_account_command<'a>() -> Command<'a, str> {
                 let main = crate::get_pair_from_str(matches, arg_main);
                 let account_id = sr25519_core::Pair::from(main);
                 let chain_api = chain_api.set_signer(account_id.clone());
-                let public_account_id: AccountId = account_id.public().into();
 
                 // compose the extrinsic
                 let xt: UncheckedExtrinsicV4<([u8; 2], AccountId)> = compose_extrinsic!(
                     chain_api,
                     "PolkadexOcex",
                     "register",
-                    public_account_id.clone()
+                    account_id.public().into()
                 );
 
                 let tx_hash = chain_api
                     .send_extrinsic(xt.hex_encode(), XtStatus::Finalized)
                     .unwrap()
                     .unwrap();
-                println!("[+] Successfully registered new account {}. Hash: {:?}\n", public_account_id, tx_hash);
+                println!("[+] Transaction got finalized.. Hash: {:?}\n", tx_hash);
                 Ok(())
             })
 }
@@ -105,14 +104,14 @@ pub fn register_proxy_command<'a>() -> Command<'a, str> {
                 "PolkadexOcex",
                 "add_proxy",
                 main_account_id.public().into(),
-                proxy.clone()
+                proxy
             );
 
             let tx_hash = chain_api
                 .send_extrinsic(xt.hex_encode(), XtStatus::Finalized)
                 .unwrap()
                 .unwrap();
-            println!("[+] Successfully registered new proxy account: {}. Hash: {:?}\n", proxy, tx_hash);
+            println!("[+] Transaction got finalized. Hash: {:?}\n", tx_hash);
             Ok(())
         })
 }
@@ -155,14 +154,14 @@ pub fn remove_proxy_command<'a>() -> Command<'a, str> {
                 "PolkadexOcex",
                 "remove_proxy",
                 main_account_id.public().into(),
-                proxy.clone()
+                proxy
             );
 
             let tx_hash = chain_api
                 .send_extrinsic(xt.hex_encode(), XtStatus::Finalized)
                 .unwrap()
                 .unwrap();
-            println!("[+] Successfully removed proxy account: {}. Hash: {:?}\n", proxy,  tx_hash);
+            println!("[+] Transaction got finalized. Hash: {:?}\n", tx_hash);
             Ok(())
         })
 }

--- a/client/src/ocex_commands.rs
+++ b/client/src/ocex_commands.rs
@@ -1,0 +1,67 @@
+use log::*;
+
+use base58::{FromBase58, ToBase58};
+use clap::{AppSettings, Arg, ArgMatches};
+use clap_nested::{Command, Commander};
+use codec::{Decode, Encode};
+use log::*;
+use my_node_runtime::{
+    pallet_substratee_registry::{Enclave, Request},
+    AccountId, BalancesCall, Call, Event, Hash,
+};
+use polkadex_sgx_primitives::types::DirectRequest;
+use sgx_crypto_helper::rsa3072::Rsa3072PubKey;
+use sp_application_crypto::{ed25519, sr25519};
+use sp_core::{crypto::Ss58Codec, sr25519 as sr25519_core, Pair, H256};
+use sp_keyring::AccountKeyring;
+use sp_runtime::MultiSignature;
+use std::convert::TryFrom;
+use std::result::Result as StdResult;
+use std::sync::mpsc::channel;
+use std::thread;
+use std::time::{Duration, UNIX_EPOCH};
+use substrate_api_client::{
+    compose_extrinsic, compose_extrinsic_offline,
+    events::EventsDecoder,
+    extrinsic::xt_primitives::{GenericAddress, UncheckedExtrinsicV4},
+    node_metadata::Metadata,
+    utils::FromHexString,
+    Api, XtStatus,
+};
+
+pub fn register_account_command<'a>() -> Command<'a, str> {
+        Command::new("register-account")
+            .description("Registers a new main account to the polkadex offchain registry")
+            .options(|app| {
+                app.arg(
+                    Arg::with_name("from")
+                        .takes_value(true)
+                        .required(true)
+                        .value_name("SS58")
+                        .help("Sender's on-chain AccountId in ss58check format"),
+                )
+            })
+            .runner(move |_args: &str, matches: &ArgMatches<'_>| {
+                let chain_api = crate::get_chain_api(matches);
+
+                // get the sender
+                let arg_from = matches.value_of("from").unwrap();
+                let from = crate::get_pair_from_str(matches, arg_from);
+                let account_id = sr25519_core::Pair::from(from);
+                let chain_api = chain_api.set_signer(account_id.clone());
+
+                // compose the extrinsic
+                let xt: UncheckedExtrinsicV4<([u8; 2], AccountId)> = compose_extrinsic!(
+                    chain_api,
+                    "PolkadexOcex",
+                    "register",
+                    account_id.public().into()
+                );
+
+                let tx_hash = chain_api
+                    .send_extrinsic(xt.hex_encode(), XtStatus::Finalized)
+                    .unwrap();
+                println!("[+] TrustedOperation got finalized. Hash: {:?}\n", tx_hash);
+                Ok(())
+            })
+}

--- a/client/src/ocex_commands.rs
+++ b/client/src/ocex_commands.rs
@@ -178,7 +178,7 @@ pub fn withdraw_command<'a>() -> Command<'a, str> {
             let chain_api = crate::get_chain_api(matches);
 
             // get the main account /sender
-            let arg_main = matches.value_of("main").unwrap();
+            let arg_main = matches.value_of("accountid").unwrap();
             let main = crate::get_pair_from_str(matches, arg_main);
             let main_account_id = sr25519_core::Pair::from(main);
             let chain_api = chain_api.set_signer(main_account_id.clone());

--- a/client/src/ocex_commands.rs
+++ b/client/src/ocex_commands.rs
@@ -49,19 +49,21 @@ pub fn register_account_command<'a>() -> Command<'a, str> {
                 let main = crate::get_pair_from_str(matches, arg_main);
                 let account_id = sr25519_core::Pair::from(main);
                 let chain_api = chain_api.set_signer(account_id.clone());
+                let public_account_id: AccountId = account_id.public().into();
 
                 // compose the extrinsic
                 let xt: UncheckedExtrinsicV4<([u8; 2], AccountId)> = compose_extrinsic!(
                     chain_api,
                     "PolkadexOcex",
                     "register",
-                    account_id.public().into()
+                    public_account_id.clone()
                 );
 
                 let tx_hash = chain_api
                     .send_extrinsic(xt.hex_encode(), XtStatus::Finalized)
+                    .unwrap()
                     .unwrap();
-                println!("[+] TrustedOperation got finalized. Hash: {:?}\n", tx_hash);
+                println!("[+] Successfully registered new account {}. Hash: {:?}\n", public_account_id, tx_hash);
                 Ok(())
             })
 }
@@ -103,13 +105,64 @@ pub fn register_proxy_command<'a>() -> Command<'a, str> {
                 "PolkadexOcex",
                 "add_proxy",
                 main_account_id.public().into(),
-                proxy
+                proxy.clone()
             );
 
             let tx_hash = chain_api
                 .send_extrinsic(xt.hex_encode(), XtStatus::Finalized)
+                .unwrap()
                 .unwrap();
-            println!("[+] TrustedOperation got finalized. Hash: {:?}\n", tx_hash);
+            println!("[+] Successfully registered new proxy account: {}. Hash: {:?}\n", proxy, tx_hash);
+            Ok(())
+        })
+}
+
+
+pub fn remove_proxy_command<'a>() -> Command<'a, str> {
+    Command::new("remove-proxy")
+        .description("Removes a registered proxy account from the polkadex offchain registry")
+        .options(|app| {
+            app.arg(
+                Arg::with_name("main")
+                    .takes_value(true)
+                    .required(true)
+                    .value_name("SS58")
+                    .help("Sender's on-chain AccountId in ss58check format"),
+            )
+            .arg(
+                Arg::with_name("proxy")
+                    .takes_value(true)
+                    .required(true)
+                    .value_name("SS58")
+                    .help("Sender's proxy AccountId in ss58check format"),
+            )
+        })
+        .runner(move |_args: &str, matches: &ArgMatches<'_>| {
+            let chain_api = crate::get_chain_api(matches);
+
+            // get the main account /sender
+            let arg_main = matches.value_of("main").unwrap();
+            let main = crate::get_pair_from_str(matches, arg_main);
+            let main_account_id = sr25519_core::Pair::from(main);
+            let chain_api = chain_api.set_signer(main_account_id.clone());
+
+            // get the proxy account
+            let proxy = crate::get_accountid_from_str(matches.value_of("proxy").unwrap());
+
+            // compose the extrinsic
+            let xt: UncheckedExtrinsicV4<([u8; 2], AccountId, AccountId)> = compose_extrinsic!(
+                chain_api,
+                "PolkadexOcex",
+                "remove_proxy",
+                main_account_id.public().into(),
+                proxy.clone()
+            );
+
+            let tx_hash = chain_api
+                .send_extrinsic(xt.hex_encode(), XtStatus::Finalized)
+                .unwrap()
+                .unwrap();
+            println!("[+] Successfully removed proxy account: {}. Hash: {:?}\n", proxy,  tx_hash);
             Ok(())
         })
 }

--- a/client/src/ocex_commands.rs
+++ b/client/src/ocex_commands.rs
@@ -34,7 +34,7 @@ pub fn register_account_command<'a>() -> Command<'a, str> {
             .description("Registers a new main account to the polkadex offchain registry")
             .options(|app| {
                 app.arg(
-                    Arg::with_name("from")
+                    Arg::with_name("main")
                         .takes_value(true)
                         .required(true)
                         .value_name("SS58")
@@ -44,10 +44,10 @@ pub fn register_account_command<'a>() -> Command<'a, str> {
             .runner(move |_args: &str, matches: &ArgMatches<'_>| {
                 let chain_api = crate::get_chain_api(matches);
 
-                // get the sender
-                let arg_from = matches.value_of("from").unwrap();
-                let from = crate::get_pair_from_str(matches, arg_from);
-                let account_id = sr25519_core::Pair::from(from);
+                // get the main account / sender
+                let arg_main = matches.value_of("main").unwrap();
+                let main = crate::get_pair_from_str(matches, arg_main);
+                let account_id = sr25519_core::Pair::from(main);
                 let chain_api = chain_api.set_signer(account_id.clone());
 
                 // compose the extrinsic
@@ -64,4 +64,52 @@ pub fn register_account_command<'a>() -> Command<'a, str> {
                 println!("[+] TrustedOperation got finalized. Hash: {:?}\n", tx_hash);
                 Ok(())
             })
+}
+
+pub fn register_proxy_command<'a>() -> Command<'a, str> {
+    Command::new("register-proxy")
+        .description("Registers a new proxy account to the polkadex offchain registry")
+        .options(|app| {
+            app.arg(
+                Arg::with_name("main")
+                    .takes_value(true)
+                    .required(true)
+                    .value_name("SS58")
+                    .help("Sender's on-chain AccountId in ss58check format"),
+            )
+            .arg(
+                Arg::with_name("proxy")
+                    .takes_value(true)
+                    .required(true)
+                    .value_name("SS58")
+                    .help("Sender's proxy AccountId in ss58check format"),
+            )
+        })
+        .runner(move |_args: &str, matches: &ArgMatches<'_>| {
+            let chain_api = crate::get_chain_api(matches);
+
+            // get the main account /sender
+            let arg_main = matches.value_of("main").unwrap();
+            let main = crate::get_pair_from_str(matches, arg_main);
+            let main_account_id = sr25519_core::Pair::from(main);
+            let chain_api = chain_api.set_signer(main_account_id.clone());
+
+            // get the proxy account
+            let proxy = crate::get_accountid_from_str(matches.value_of("proxy").unwrap());
+
+            // compose the extrinsic
+            let xt: UncheckedExtrinsicV4<([u8; 2], AccountId, AccountId)> = compose_extrinsic!(
+                chain_api,
+                "PolkadexOcex",
+                "add_proxy",
+                main_account_id.public().into(),
+                proxy
+            );
+
+            let tx_hash = chain_api
+                .send_extrinsic(xt.hex_encode(), XtStatus::Finalized)
+                .unwrap();
+            println!("[+] TrustedOperation got finalized. Hash: {:?}\n", tx_hash);
+            Ok(())
+        })
 }

--- a/stf/src/commands/common_args.rs
+++ b/stf/src/commands/common_args.rs
@@ -65,7 +65,7 @@ pub fn add_main_account_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
             .long(ACCOUNT_ID_ARG_NAME)
             .takes_value(true)
             .required(true)
-            .value_name("STRING")
+            .value_name("SS58")
             .help("Account/User ID"),
     )
 }
@@ -76,7 +76,7 @@ pub fn add_proxy_account_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
             .long(PROXY_ACCOUNT_ID_ARG_NAME)
             .takes_value(true)
             .required(false) // proxy account is optional
-            .value_name("STRING")
+            .value_name("SS58")
             .help("Proxy Account ID"),
     )
 }

--- a/stf/src/commands/mod.rs
+++ b/stf/src/commands/mod.rs
@@ -21,7 +21,7 @@ pub mod place_order;
 pub mod withdraw;
 
 mod account_details;
-mod common_args;
-mod common_args_processing;
+pub mod common_args;
+pub mod common_args_processing;
 
 mod test_utils;


### PR DESCRIPTION
Adds the calls that the user should be able to issue directly to the node from the client.
The commands can be called in the /bin folder. Examples:
```
./substratee-client -p NODEPORT -P WORKERPORT register-account //Alice
./substratee-client -p NODEPORT -P WORKERPORT register-proxy //Alice //AliceIcognito
./substratee-client -p NODEPORT -P WORKERPORT remove-proxy //Alice //AliceIcognito
./substratee-client -p NODEPORT -P WORKERPORT withdraw --accountid=//Bob --tokenid=dot --quantity=1000
./substratee-client -p NODEPORT -P WORKERPORT deposit --accountid=//Bob --tokenid=dot --quantity=1000
```

Closes #77 