### PR TITLE
Cache unit tests

### DIFF
--- a/enclave/src/openfinex/openfinex_api_impl.rs
+++ b/enclave/src/openfinex/openfinex_api_impl.rs
@@ -58,8 +58,8 @@ impl OpenFinexApi for OpenFinexApiImpl {
 
         let request = self
             .create_builder(RequestType::CreateOrder, request_id)
-            .push_optional_parameter(Some(user_id))
-            .push_optional_parameter(None) // empty parameter for nickname
+            .push_optional_parameter(None) // empty parameter for uid
+            .push_optional_parameter(Some(user_id)) // nickname
             .push_parameter(market_id_to_request_string(order.market_id))
             .push_parameter(market_type)
             .push_parameter(order_type)

--- a/enclave/src/polkadex_cache/create_order_cache.rs
+++ b/enclave/src/polkadex_cache/create_order_cache.rs
@@ -23,6 +23,9 @@ use std::sync::atomic::{AtomicPtr, Ordering};
 use std::sync::{Arc, SgxMutex};
 use crate::polkadex_cache::cache_api::{RequestId, StaticStorageApi, CacheResult};
 
+use codec::{Encode, Decode};
+use std::string::{String, ToString};
+
 static CREATE_ORDER_CACHE: AtomicPtr<()> = AtomicPtr::new(0 as *mut ());
 
 
@@ -68,7 +71,7 @@ impl StaticStorageApi for CreateOrderCache {
 
 impl CreateOrderCache {
     /// removes the given order from the cache. Returns the value of
-    /// the key if previously present
+    /// the given key if previously present
     pub fn remove_order(&mut self, id: &RequestId) -> Option<Order> {
         self.order_map.remove(id)
     }
@@ -90,4 +93,111 @@ impl CreateOrderCache {
     fn increment_request_id(&mut self) {
         self.request_id = self.request_id.saturating_add(1)
     }
+}
+
+
+pub mod tests {
+    use super::*;
+    use crate::test_orderbook_storage;
+
+
+    pub fn test_initialize_and_lock_storage() {
+        // given
+        CreateOrderCache::initialize();
+
+        // when
+        let mutex = CreateOrderCache::load().unwrap();
+
+        // then
+        mutex.lock().unwrap();
+    }
+
+    pub fn test_insert_order_and_increment() {
+        // given
+        CreateOrderCache::initialize();
+        let mut cache = CreateOrderCache::load()
+            .unwrap()
+            .lock()
+            .unwrap();
+        let orders = test_orderbook_storage::get_dummy_orders();
+        assert_eq!(cache.request_id(), 0);
+
+        // when
+        let none = cache.insert_order(orders[0].clone());
+
+        // then
+        assert!(none.is_none()); // no previously inserted order should be there
+        assert_eq!(cache.request_id(), 1);
+    }
+
+    pub fn test_remove_order() {
+        // given
+        CreateOrderCache::initialize();
+        let mut cache = CreateOrderCache::load()
+            .unwrap()
+            .lock()
+            .unwrap();
+        let orders = test_orderbook_storage::get_dummy_orders();
+        let order_0_id = cache.request_id();
+        assert_eq!(order_0_id, 0);
+        cache.insert_order(orders[0].clone());
+        let order_1_id = cache.request_id();
+        assert_eq!(order_1_id, 1);
+        cache.insert_order(orders[1].clone());
+
+        // when
+        let order_1 = cache.remove_order(&order_1_id).unwrap();
+        let none = cache.remove_order(&order_1_id);
+
+        // then
+        assert!(none.is_none());
+        assert_eq!(order_1, orders[1]);
+        assert_eq!(cache.request_id(), 2);
+    }
+
+    pub fn test_reload_cache() {
+        // given
+        let orders = test_orderbook_storage::get_dummy_orders();
+        {
+            CreateOrderCache::initialize();
+        }
+        {
+            let mut cache = CreateOrderCache::load()
+                .unwrap()
+                .lock()
+                .unwrap();
+            let order_0_id = cache.request_id();
+            assert_eq!(order_0_id, 0);
+            cache.insert_order(orders[0].clone());
+            let order_1_id = cache.request_id();
+            assert_eq!(order_1_id, 1);
+            cache.insert_order(orders[1].clone());
+        }
+
+        // when
+        {
+            let mut cache = CreateOrderCache::load()
+                .unwrap()
+                .lock()
+                .unwrap();
+            let order_1 = cache.remove_order(&1).unwrap();
+            let none = cache.remove_order(&1);
+
+            assert!(none.is_none());
+            assert_eq!(order_1, orders[1]);
+        }
+
+
+        // then
+        let mut cache = CreateOrderCache::load()
+            .unwrap()
+            .lock()
+            .unwrap();
+        let order_1 = cache.remove_order(&1);
+        assert!(order_1.is_none());
+        let order_0 = cache.remove_order(&0).unwrap();
+        assert_eq!(order_0, orders[0]);
+        assert_eq!(cache.request_id(), 2);
+    }
+
 }

--- a/enclave/src/tests.rs
+++ b/enclave/src/tests.rs
@@ -25,6 +25,7 @@ use crate::test_orderbook_storage;
 use crate::test_polkadex_gateway;
 use crate::test_proxy;
 use crate::top_pool;
+use crate::polkadex_cache;
 
 use crate::{Timeout, WorkerRequest, WorkerResponse};
 use log::*;
@@ -74,6 +75,12 @@ use rpc::{
 #[no_mangle]
 pub extern "C" fn test_main_entrance() -> size_t {
     rsgx_unit_tests!(
+        // Polkadex cache
+        polkadex_cache::create_order_cache::tests::test_initialize_and_lock_storage,
+        polkadex_cache::create_order_cache::tests::test_insert_order_and_increment,
+        polkadex_cache::create_order_cache::tests::test_remove_order,
+        polkadex_cache::create_order_cache::tests::test_reload_cache,
+
         // Polkadex Gateway
         test_polkadex_gateway::initialize_storage, // This is not a test but initializes storage for the following tests
         test_polkadex_gateway::test_authenticate_user,

--- a/enclave/src/tests.rs
+++ b/enclave/src/tests.rs
@@ -81,6 +81,11 @@ pub extern "C" fn test_main_entrance() -> size_t {
         polkadex_cache::create_order_cache::tests::test_remove_order,
         polkadex_cache::create_order_cache::tests::test_reload_cache,
 
+        polkadex_cache::cancel_order_cache::tests::test_initialize_and_lock_storage,
+        polkadex_cache::cancel_order_cache::tests::test_insert_order_and_increment,
+        polkadex_cache::cancel_order_cache::tests::test_remove_order,
+        polkadex_cache::cancel_order_cache::tests::test_reload_cache,
+
         // Polkadex Gateway
         test_polkadex_gateway::initialize_storage, // This is not a test but initializes storage for the following tests
         test_polkadex_gateway::test_authenticate_user,


### PR DESCRIPTION
- Adds unit tests to the oder caches, closing #104
- Fixes unit tests of gateway, closes #106 
- Switches uid and nickname in openfinex request parsing, fixes #109 