### PR TITLE
Remove worker clippy warnings

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -122,7 +122,7 @@ fn main() {
         .add_cmd(
             Command::new("new-account")
                 .description("generates a new account for the substraTEE chain")
-                .runner(|_args: &str, matches: &ArgMatches<'_>| {
+                .runner(|_args: &str, _matches: &ArgMatches<'_>| {
                     let store = LocalKeystore::open(get_untrusted_keystore_path(), None).unwrap();
                     let key: sr25519::AppPair = store.generate().unwrap();
                     drop(store);
@@ -133,7 +133,7 @@ fn main() {
         .add_cmd(
             Command::new("list-accounts")
                 .description("lists all accounts in keystore for the substraTEE chain")
-                .runner(|_args: &str, matches: &ArgMatches<'_>| {
+                .runner(|_args: &str, _matches: &ArgMatches<'_>| {
                     let store = LocalKeystore::open(get_untrusted_keystore_path(), None).unwrap();
                     println!("sr25519 keys:");
                     for pubkey in store
@@ -181,10 +181,9 @@ fn main() {
                 .runner(|_args: &str, matches: &ArgMatches<'_>| {
                     let api = get_chain_api(matches);
                     let _api = api.set_signer(AccountKeyring::Alice.pair());
-                    let accounts: Vec<_> = matches.values_of("accounts").unwrap().collect();
 
                     let mut nonce = _api.get_nonce().unwrap();
-                    for account in accounts.into_iter() {
+                    for account in matches.values_of("accounts").unwrap().into_iter() {
                         let to = get_accountid_from_str(account);
                         #[allow(clippy::redundant_clone)]
                         let xt: UncheckedExtrinsicV4<_> = compose_extrinsic_offline!(
@@ -266,7 +265,7 @@ fn main() {
                     let api = get_chain_api(matches);
                     let arg_from = matches.value_of("from").unwrap();
                     let arg_to = matches.value_of("to").unwrap();
-                    let amount = u128::from_str_radix(matches.value_of("amount").unwrap(), 10)
+                    let amount =matches.value_of("amount").unwrap().parse::<u128>()
                         .expect("amount can be converted to u128");
                     let from = get_pair_from_str_untrusted(arg_from);
                     let to = get_accountid_from_str(arg_to);
@@ -369,7 +368,7 @@ fn main() {
                 })
                 .runner(move |_args: &str, matches: &ArgMatches<'_>| {
                     let chain_api = get_chain_api(matches);
-                    let amount = u128::from_str_radix(matches.value_of("amount").unwrap(), 10)
+                    let amount = matches.value_of("amount").unwrap().parse::<u128>()
                         .expect("amount can't be converted to u128");
 
                     let shard_opt = match matches.value_of("shard") {

--- a/client/src/ocex_commands.rs
+++ b/client/src/ocex_commands.rs
@@ -150,7 +150,7 @@ pub fn remove_proxy_command<'a>() -> Command<'a, str> {
 pub fn withdraw_command<'a>() -> Command<'a, str> {
     Command::new("withdraw")
         .description("withdraws the given amount of funds from the sender")
-        .options(|app| add_command_args(app))
+        .options(add_command_args)
         .runner(move |_args: &str, matches: &ArgMatches<'_>| {
             let chain_api = crate::get_chain_api(matches);
 
@@ -191,7 +191,7 @@ fn add_command_args<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
 pub fn deposit_command<'a>() -> Command<'a, str> {
     Command::new("deposit")
         .description("deposits a given amount of funds from the sender")
-        .options(|app| add_command_args(app))
+        .options(add_command_args)
         .runner(move |_args: &str, matches: &ArgMatches<'_>| {
             let chain_api = crate::get_chain_api(matches);
 

--- a/polkadex-primitives/src/lib.rs
+++ b/polkadex-primitives/src/lib.rs
@@ -43,7 +43,7 @@ impl OpenFinexUri {
     ///         port_path_str, string containing at least the port
     ///             (e.g.: 8001/api/v2/ws or 8001)
     pub fn new(ip_str: &str, port_path_str: &str) -> Self {
-        let (port_str, path_str)  = if let Some(index) = port_path_str.find("/") {
+        let (port_str, path_str)  = if let Some(index) = port_path_str.find('/') {
             port_path_str.split_at(index)
         } else {
             (port_path_str, "/")

--- a/polkadex-primitives/src/types.rs
+++ b/polkadex-primitives/src/types.rs
@@ -95,7 +95,7 @@ pub struct SignedOrder {
 impl SignedOrder {
     pub fn sign(&mut self, key_pair: &ed25519::Pair) {
         let payload = self.encode();
-        self.signature = key_pair.sign(payload.as_slice()).into();
+        self.signature = key_pair.sign(payload.as_slice());
     }
 
     pub fn verify_signature(&self, key_pair: &ed25519::Pair) -> bool {

--- a/stf/src/cli.rs
+++ b/stf/src/cli.rs
@@ -151,7 +151,7 @@ pub fn cmd(perform_operation: OperationRunner) -> MultiCommand<str, str> {
                 .runner(move |_args: &str, matches: &ArgMatches<'_>| {
                     let arg_from = matches.value_of("from").unwrap();
                     let arg_to = matches.value_of("to").unwrap();
-                    let amount = u128::from_str_radix(matches.value_of("amount").unwrap(), 10)
+                    let amount = matches.value_of("amount").unwrap().parse::<u128>()
                         .expect("amount can be converted to u128");
                     let from = get_pair_from_str_trusted(matches, arg_from);
                     let to = get_accountid_from_str(arg_to);
@@ -201,7 +201,7 @@ pub fn cmd(perform_operation: OperationRunner) -> MultiCommand<str, str> {
                 })
                 .runner(move |_args: &str, matches: &ArgMatches<'_>| {
                     let arg_who = matches.value_of("account").unwrap();
-                    let amount = u128::from_str_radix(matches.value_of("amount").unwrap(), 10)
+                    let amount = matches.value_of("amount").unwrap().parse::<u128>()
                         .expect("amount can be converted to u128");
                     let who = get_pair_from_str_trusted(matches, arg_who);
                     let signer = get_pair_from_str_trusted(matches, "//Alice");
@@ -303,7 +303,7 @@ pub fn cmd(perform_operation: OperationRunner) -> MultiCommand<str, str> {
                 .runner(move |_args: &str, matches: &ArgMatches<'_>| {
                     let arg_from = matches.value_of("from").unwrap();
                     let arg_to = matches.value_of("to").unwrap();
-                    let amount = u128::from_str_radix(matches.value_of("amount").unwrap(), 10)
+                    let amount = matches.value_of("amount").unwrap().parse::<u128>()
                         .expect("amount can be converted to u128");
                     let from = get_pair_from_str_trusted(matches, arg_from);
                     let to = get_accountid_from_str(arg_to);

--- a/stf/src/commands/account_details.rs
+++ b/stf/src/commands/account_details.rs
@@ -31,10 +31,8 @@ pub struct AccountDetails {
 
 impl AccountDetails {
     pub fn new(matches: &ArgMatches<'_>) -> Self {
-        let arg_account = matches.value_of(ACCOUNT_ID_ARG_NAME).expect(&format!(
-            "missing main account option ({})",
-            ACCOUNT_ID_ARG_NAME
-        ));
+        let arg_account = matches.value_of(ACCOUNT_ID_ARG_NAME)
+            .unwrap_or_else(|| panic!("missing main account option ({})", ACCOUNT_ID_ARG_NAME));
 
         let main_account_pair = get_pair_from_str_trusted(matches, arg_account);
 
@@ -56,7 +54,7 @@ impl AccountDetails {
     }
 
     pub fn signer_key_pair(&self) -> sr25519_core::Pair {
-        sr25519_core::Pair::from(self.signer_pair().clone())
+        sr25519_core::Pair::from(self.signer_pair())
     }
 
     pub fn signer_public_key(&self) -> sr25519_core::Public {
@@ -69,17 +67,14 @@ impl AccountDetails {
 
     /// returns a main account public key, IF the signer is a proxy, none otherwise
     pub fn main_account_public_key_if_not_signer(&self) -> Option<sr25519_core::Public> {
-        match &self.proxy_account {
-            Some(_) => Some(sr25519_core::Public::from(self.main_account.public())),
-            None => None,
-        }
+        self.proxy_account.as_ref().map(|_| sr25519_core::Public::from(self.main_account.public()))
     }
 
     #[cfg(test)]
     pub fn proxy_account_public_key(&self) -> Option<sr25519_core::Public> {
         self.proxy_account
-            .clone()
-            .map(|pa| sr25519_core::Public::from(pa.public()))
+            .as_ref()
+            .map(|_| sr25519_core::Public::from(self.main_account.public()))
     }
 }
 

--- a/stf/src/commands/account_details.rs
+++ b/stf/src/commands/account_details.rs
@@ -73,8 +73,8 @@ impl AccountDetails {
     #[cfg(test)]
     pub fn proxy_account_public_key(&self) -> Option<sr25519_core::Public> {
         self.proxy_account
-            .as_ref()
-            .map(|_| sr25519_core::Public::from(self.main_account.public()))
+            .clone()
+            .map(|pa| sr25519_core::Public::from(pa.public()))
     }
 }
 

--- a/stf/src/commands/cancel_order.rs
+++ b/stf/src/commands/cancel_order.rs
@@ -31,7 +31,7 @@ use log::*;
 pub fn cancel_order_cli_command(perform_operation: OperationRunner) -> Command<str> {
     Command::new("cancel_order")
         .description("Cancel order")
-        .options(|app| add_app_args(app))
+        .options(add_app_args)
         .runner(move |_args: &str, matches: &ArgMatches<'_>| {
             command_runner(matches, perform_operation)
         })

--- a/stf/src/commands/common_args_processing.rs
+++ b/stf/src/commands/common_args_processing.rs
@@ -32,13 +32,13 @@ pub fn get_order_from_matches(
     let arg_order_type = get_order_type_from_str(
         matches
             .value_of(ORDER_TYPE_ARG_NAME)
-            .expect(format!("missing {} argument", ORDER_TYPE_ARG_NAME).as_str()),
+            .unwrap_or_else(|| panic!("missing {} argument", ORDER_TYPE_ARG_NAME)),
     )?;
 
     let arg_order_side = get_order_side_from_str(
         matches
             .value_of(ORDER_SIDE_ARG_NAME)
-            .expect(format!("missing {} argument", ORDER_SIDE_ARG_NAME).as_str()),
+            .unwrap_or_else(|| panic!("missing {} argument", ORDER_SIDE_ARG_NAME)),
     )?;
 
     let arg_quantity = get_amount_from_matches(matches, QUANTITY_ARG_NAME);
@@ -58,13 +58,13 @@ pub fn get_order_from_matches(
         price: arg_price,
     };
 
-    return Ok(order);
+    Ok(order)
 }
 
 pub fn get_cancel_order_from_matches(matches: &ArgMatches, main_account: AccountId) -> Result<CancelOrder, String> {
     let order_id = matches
         .value_of(ORDER_UUID_ARG_NAME)
-        .expect(format!("missing {} argument", ORDER_UUID_ARG_NAME).as_str())
+        .unwrap_or_else(|| panic!("missing {} argument", ORDER_UUID_ARG_NAME))
         .as_bytes()
         .to_vec();
 
@@ -82,7 +82,7 @@ pub fn get_cancel_order_from_matches(matches: &ArgMatches, main_account: Account
 pub fn get_token_id_from_matches<'a>(matches: &'a ArgMatches<'a>) -> Result<AssetId, String> {
     let token_id_str = matches
         .value_of(TOKEN_ID_ARG_NAME)
-        .expect(format!("missing {} argument", TOKEN_ID_ARG_NAME).as_str());
+        .unwrap_or_else(|| panic!("missing {} argument", TOKEN_ID_ARG_NAME));
 
     get_asset_id_from_str(token_id_str)
 }
@@ -100,13 +100,13 @@ fn get_market_id_from_matches<'a>(matches: &'a ArgMatches<'a>) -> Result<MarketI
     let market_id_base = get_asset_id_from_str(
         matches
             .value_of(MARKET_ID_BASE_ARG_NAME)
-            .expect(format!("missing {} argument", MARKET_ID_BASE_ARG_NAME).as_str()),
+            .unwrap_or_else(|| panic!("missing {} argument", MARKET_ID_BASE_ARG_NAME)),
     )?;
 
     let market_id_quote = get_asset_id_from_str(
         matches
             .value_of(MARKET_ID_QUOTE_ARG_NAME)
-            .expect(format!("missing {} argument", MARKET_ID_QUOTE_ARG_NAME).as_str()),
+            .unwrap_or_else(|| panic!("missing {} argument", MARKET_ID_QUOTE_ARG_NAME)),
     )?;
 
     Ok(MarketId {
@@ -120,7 +120,7 @@ fn get_amount_from_matches(matches: &ArgMatches<'_>, arg_name: &str) -> u128 {
 }
 
 fn get_amount_from_str(arg: &str) -> u128 {
-    u128::from_str_radix(arg, 10).expect(&format!("failed to convert {} into an integer", arg))
+    arg.parse::<u128>().unwrap_or_else(|_| panic!("failed to convert {} into an integer", arg))
 }
 
 fn get_asset_id_from_str(arg: &str) -> Result<AssetId, String> {
@@ -132,7 +132,7 @@ fn get_asset_id_from_str(arg: &str) -> Result<AssetId, String> {
     }
 }
 
-fn get_order_type_from_str<'a>(arg: &str) -> Result<OrderType, String> {
+fn get_order_type_from_str(arg: &str) -> Result<OrderType, String> {
     match arg.to_ascii_lowercase().as_ref() {
         "limit" => Ok(OrderType::LIMIT),
         "market" => Ok(OrderType::MARKET),
@@ -142,7 +142,7 @@ fn get_order_type_from_str<'a>(arg: &str) -> Result<OrderType, String> {
     }
 }
 
-fn get_order_side_from_str<'a>(arg: &str) -> Result<OrderSide, String> {
+fn get_order_side_from_str(arg: &str) -> Result<OrderSide, String> {
     match arg.to_ascii_lowercase().as_ref() {
         "bid" => Ok(OrderSide::BID),
         "ask" => Ok(OrderSide::ASK),

--- a/stf/src/commands/get_balance.rs
+++ b/stf/src/commands/get_balance.rs
@@ -30,7 +30,7 @@ pub fn get_balance_cli_command<'a>(
 ) -> Command<'a, str> {
     Command::new("get_balance")
         .description("Get the balance")
-        .options(|app| add_command_args(app))
+        .options(add_command_args)
         .runner(move |_args: &str, matches: &ArgMatches<'_>| {
             command_runner(matches, perform_operation)
         })

--- a/stf/src/commands/place_order.rs
+++ b/stf/src/commands/place_order.rs
@@ -35,7 +35,7 @@ pub fn place_order_cli_command<'a>(
 ) -> Command<'a, str> {
     Command::new("place_order")
         .description("Place order")
-        .options(|app| add_common_order_command_args(app))
+        .options(add_common_order_command_args)
         .runner(move |_args: &str, matches: &ArgMatches<'_>| {
             command_runner(matches, perform_operation)
         })

--- a/stf/src/commands/withdraw.rs
+++ b/stf/src/commands/withdraw.rs
@@ -35,7 +35,7 @@ pub fn withdraw_cli_command<'a>(
 ) -> Command<'a, str> {
     Command::new("withdraw")
         .description("Withdraw")
-        .options(|app| add_command_args(app))
+        .options(add_command_args)
         .runner(move |_args: &str, matches: &ArgMatches<'_>| {
             command_runner(matches, perform_operation)
         })

--- a/stf/src/lib.rs
+++ b/stf/src/lib.rs
@@ -236,22 +236,14 @@ impl TrustedCall {
             TrustedCall::balance_unshield(_, _, _, _) => None,
             TrustedCall::balance_shield(_, _) => None,
 
-            TrustedCall::place_order(signer, _, main_account_option) => match main_account_option {
-                Some(_) => Some(signer.clone()),
-                None => None,
-            },
+            TrustedCall::place_order(signer, _, main_account_option) =>
+                main_account_option.as_ref().map(|_| signer.clone()),
 
-            TrustedCall::cancel_order(signer, _, main_account_option) => {
-                match main_account_option {
-                    Some(_) => Some(signer.clone()),
-                    None => None,
-                }
-            }
+            TrustedCall::cancel_order(signer, _, main_account_option) =>
+                main_account_option.as_ref().map(|_| signer.clone()),
 
-            TrustedCall::withdraw(signer, _, _, main_account_option) => match main_account_option {
-                Some(_) => Some(signer.clone()),
-                None => None,
-            },
+            TrustedCall::withdraw(signer, _, _, main_account_option) =>
+                main_account_option.as_ref().map(|_| signer.clone()),
         }
     }
 
@@ -318,11 +310,8 @@ impl TrustedGetter {
             TrustedGetter::free_balance(_) => None,
             TrustedGetter::reserved_balance(_) => None,
             TrustedGetter::nonce(_) => None,
-            TrustedGetter::get_balance(signer, _, main_account_option) => match main_account_option
-            {
-                Some(_) => Some(signer.clone()),
-                None => None,
-            },
+            TrustedGetter::get_balance(signer, _, main_account_option) =>
+                main_account_option.as_ref().map(|_| signer.clone())
         }
     }
 

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -591,8 +591,7 @@ pub fn sync_chain(
         return curr_head.block.header;
     }
 
-    let mut blocks_to_sync = Vec::<SignedBlock>::new();
-    blocks_to_sync.push(curr_head.clone());
+    let mut blocks_to_sync = vec![curr_head.clone()];
 
     // Todo: Check, is this dangerous such that it could be an eternal or too big loop?
     let mut head = curr_head.clone();
@@ -827,6 +826,9 @@ pub unsafe extern "C" fn ocall_write_order_to_db(
     status
 }
 
+/// # Safety
+///
+/// FFI are always unsafe
 #[no_mangle]
 pub unsafe extern "C" fn ocall_send_release_extrinsic(
     extrinsic: *const u8,

--- a/worker/src/polkadex.rs
+++ b/worker/src/polkadex.rs
@@ -17,7 +17,7 @@ pub fn get_main_accounts(header: Header, api: &Api<sr25519::Pair>) -> Vec<Polkad
 
     while last_account.account.next != None {
         last_account = get_storage_and_proof(
-            last_account.account.next.clone().unwrap().into(),
+            last_account.account.next.clone().unwrap(),
             &header,
             api,
         );
@@ -39,7 +39,6 @@ pub fn get_storage_and_proof(
             Some(header.hash()),
         )
         .unwrap()
-        .map(|account: LinkedAccount| account)
         .unwrap();
 
     let last_acc_proof: Vec<Vec<u8>> = api

--- a/worker/src/polkadex_db.rs
+++ b/worker/src/polkadex_db.rs
@@ -61,7 +61,7 @@ impl KVStore for RocksDB {
         let ptr = ORDERBOOK_MIRROR.load(Ordering::SeqCst) as *mut Mutex<RocksDB>;
         if ptr.is_null() {
             println!(" Unable to load the pointer");
-            return Err(PolkadexDBError::UnableToLoadPointer);
+            Err(PolkadexDBError::UnableToLoadPointer)
         } else {
             Ok(unsafe { &*ptr })
         }
@@ -85,7 +85,7 @@ impl KVStore for RocksDB {
         let orderbook_mirror: MutexGuard<RocksDB> = mutex.lock().unwrap();
         println!("Searching for Key");
         match orderbook_mirror.db.get(k) {
-            Ok(Some(mut v)) => match SignedOrder::from_vec(&mut v.as_mut()) {
+            Ok(Some(v)) => match SignedOrder::from_vec(&v) {
                 Ok(order) => {
                     println!("Found Key");
                     Ok(Some(order))


### PR DESCRIPTION
Removes all warnings (clippy and compiler) of:

- client
- worker

I've not touched the enclave yet, because there is still a lot of work in progress