### PR TITLE
adds `make update`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,20 @@ mrenclave:
 mrsigner:
 	@$(SGX_ENCLAVE_SIGNER) dump -enclave ./bin/enclave.signed.so -dumpfile df.out && ./extract_identity --mrsigner < df.out && rm df.out
 
+.PHONY: update
+update:
+	@echo "Running cargo update.."
+	@cargo update
+	@echo "cargo update in enclave directory"
+	@cd enclave && cargo update
+	@cd enclave && cargo update -p sp-std --precise e5437efefa82bd8eb567f1245f0a7443ac4e4fe7
+	@cd enclave && cargo update -p sp-std --precise e5437efefa82bd8eb567f1245f0a7443ac4e4fe7
+	@cd enclave && cargo update -p sgx_tstd --precise ed9e7cce4fd40efd7a256d5c4be1c5f00778a5bb
+	@cd enclave && cargo update -p sgx_tstd --precise ed9e7cce4fd40efd7a256d5c4be1c5f00778a5bb
+	@cargo update -p sp-std --precise e5437efefa82bd8eb567f1245f0a7443ac4e4fe7
+	@cargo update -p sp-std --precise e5437efefa82bd8eb567f1245f0a7443ac4e4fe7
+	@cargo update -p sgx_tstd --precise ed9e7cce4fd40efd7a256d5c4be1c5f00778a5bb
+	@cargo update -p sgx_tstd --precise ed9e7cce4fd40efd7a256d5c4be1c5f00778a5bb
 .PHONY: identity
 identity: mrenclave mrsigner
 


### PR DESCRIPTION
Adds  `make update` command to the Makefile, replacing the need of doing complicated cargo updates..

While writing the Tutorial about how to correctly update the worker, I noted that simply writing a make file command is easier than explaining everything.. 