### PR TITLE
Query OpenFinex for market information to parse MarketId

### DIFF
--- a/enclave/src/openfinex/market.rs
+++ b/enclave/src/openfinex/market.rs
@@ -1,0 +1,73 @@
+// This file is part of Polkadex.
+
+// Copyright (C) 2020-2021 Polkadex oü.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use serde::{Deserialize, Serialize};
+use std::{string::String, string::ToString};
+
+//{"id":"btcusd","name":"BTC/USD","base_unit":"btc","quote_unit":"usd","state":"enabled","amount_precision":4,
+// "price_precision":4,"min_price":"0.0001","max_price":"0","min_amount":"0.0001","position":100,"filters":[]}
+
+/// Market object given by OpenFinex as JSON string
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct Market {
+    pub id: String,
+    pub name: String,
+    pub base_unit: String,
+    pub quote_unit: String,
+    pub state: MarketState,
+    pub amount_precision: u128,
+    pub price_precision: u128,
+    //min_price: String,
+    //max_price: String,
+    //min_amount: String,
+    //position: u128,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[allow(non_camel_case_types)]
+pub enum MarketState {
+    enabled,
+    disabled,
+}
+
+pub mod tests {
+
+    use super::*;
+
+    pub fn test_deserialize_market_usdbtc() {
+        let json_string = r#"{"id":"btcusd","name":"BTC/USD","base_unit":"btc","quote_unit":"usd","state":"enabled","amount_precision":4,"price_precision":4,"min_price":"0.0001","max_price":"0","min_amount":"0.0001","position":100,"filters":[]}"#.to_string();
+
+        let market: Market = serde_json::from_str(json_string.as_str()).unwrap();
+        assert_eq!("btcusd", market.id);
+        assert_eq!("BTC/USD", market.name);
+        assert_eq!("btc", market.base_unit);
+        assert_eq!("usd", market.quote_unit);
+        assert_eq!(MarketState::enabled, market.state);
+    }
+
+    pub fn test_deserialize_market_trsteth() {
+        let json_string = r#"{"id":"trsteth","name":"TRST/ETH","base_unit":"trst","quote_unit":"eth","state":"enabled","amount_precision":4,"price_precision":4,"min_price":"0.0001","max_price":"0","min_amount":"0.0001","position":105,"filters":[]}"#.to_string();
+
+        let market: Market = serde_json::from_str(json_string.as_str()).unwrap();
+        assert_eq!("trsteth", market.id);
+        assert_eq!("TRST/ETH", market.name);
+        assert_eq!("trst", market.base_unit);
+        assert_eq!("eth", market.quote_unit);
+        assert_eq!(MarketState::enabled, market.state);
+    }
+}

--- a/enclave/src/openfinex/market_repo.rs
+++ b/enclave/src/openfinex/market_repo.rs
@@ -1,0 +1,119 @@
+// This file is part of Polkadex.
+
+// Copyright (C) 2020-2021 Polkadex oü.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::openfinex::market::Market;
+use crate::openfinex::openfinex_types::{RequestId, RequestType};
+use crate::openfinex::request_builder::OpenFinexRequestBuilder;
+use crate::polkadex_cache::cache_api::CacheProvider;
+use crate::polkadex_cache::market_cache::MarketCache;
+use log::*;
+use std::sync::Arc;
+use std::{fmt::Display, fmt::Formatter, fmt::Result as FormatResult, string::String, vec::Vec};
+
+#[derive(Eq, Debug, PartialOrd, PartialEq)]
+pub enum MarketRepositoryError {
+    FailedToLoadCache,
+    FailedToLockCache,
+}
+
+impl Display for MarketRepositoryError {
+    fn fmt(&self, f: &mut Formatter) -> FormatResult {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// callback trait for receiving markets updates
+pub trait MarketsRequestCallback {
+    fn update_markets(
+        &self,
+        request_id: RequestId,
+        json_strings: &Vec<String>,
+    ) -> Result<(), MarketRepositoryError>;
+}
+
+/// trait for sending market update requests
+pub trait MarketsRequestSender {
+    fn get_markets_ws_request(&self) -> Result<String, MarketRepositoryError>;
+}
+
+/// a market repository, implementing requesting, receiving and storing markets updates from OpenFinex
+pub struct MarketRepository {
+    cache_provider: Arc<dyn CacheProvider<MarketCache>>,
+}
+
+impl MarketRepository {
+    pub fn new(cache_provider: Arc<dyn CacheProvider<MarketCache>>) -> Self {
+        MarketRepository { cache_provider }
+    }
+}
+
+impl MarketsRequestCallback for MarketRepository {
+    fn update_markets(
+        &self,
+        request_id: u128,
+        json_strings: &Vec<String>,
+    ) -> Result<(), MarketRepositoryError> {
+        let mutex = self
+            .cache_provider
+            .load()
+            .map_err(|_| MarketRepositoryError::FailedToLoadCache)?;
+        let mut cache = mutex.lock().map_err(|e| {
+            error!("Could not acquire lock on market cache pointer: {}", e);
+            MarketRepositoryError::FailedToLockCache
+        })?;
+
+        let markets = json_strings
+            .iter()
+            .filter_map(|s| map_string_to_market(s))
+            .collect();
+
+        cache.set_markets(request_id, markets);
+
+        Ok(())
+    }
+}
+
+impl MarketsRequestSender for MarketRepository {
+    fn get_markets_ws_request(&self) -> Result<String, MarketRepositoryError> {
+        let mutex = self
+            .cache_provider
+            .load()
+            .map_err(|_| MarketRepositoryError::FailedToLoadCache)?;
+        let cache = mutex.lock().map_err(|e| {
+            error!("Could not acquire lock on market cache pointer: {}", e);
+            MarketRepositoryError::FailedToLockCache
+        })?;
+        let request_id = cache.request_id();
+
+        let request_builder = OpenFinexRequestBuilder::new(RequestType::GetMarkets, request_id);
+
+        let request = request_builder.build();
+        Ok(request.to_request_string())
+    }
+}
+
+fn map_string_to_market(json_string: &String) -> Option<Market> {
+    let market: Option<Market> = match serde_json::from_str(json_string.as_str()) {
+        Ok(m) => Some(m),
+        Err(e) => {
+            error!("Failed to deserialize string to a Market object: {}", e);
+            None
+        }
+    };
+    market
+}

--- a/enclave/src/openfinex/mod.rs
+++ b/enclave/src/openfinex/mod.rs
@@ -18,8 +18,15 @@
 
 mod client_utils;
 mod jwt;
+mod market_repo;
+mod response_object_mapper;
+mod response_parser;
 
+// most of these could be private, but because the tests are inside the same modules
+// and are not discovered using 'cargo test', they have to be public
+// in some cases we decided to have the tests in a separate file, those modules can be kept private
 pub mod fixed_point_number_converter;
+pub mod market;
 pub mod openfinex_api;
 pub mod openfinex_api_impl;
 pub mod openfinex_client;
@@ -28,8 +35,6 @@ pub mod request_builder;
 pub mod request_id_generator;
 pub mod response_handler;
 pub mod response_lexer;
-mod response_object_mapper;
-mod response_parser;
 pub mod string_serialization;
 
 pub mod tests;

--- a/enclave/src/openfinex/openfinex_api_impl.rs
+++ b/enclave/src/openfinex/openfinex_api_impl.rs
@@ -20,15 +20,14 @@ pub extern crate alloc;
 use crate::openfinex::fixed_point_number_converter::FixedPointNumberConverter;
 use crate::openfinex::openfinex_api::{OpenFinexApi, OpenFinexApiError, OpenFinexApiResult};
 use crate::openfinex::openfinex_client::OpenFinexClientInterface;
-use crate::openfinex::openfinex_types::{OpenFinexDecimal, RequestId, RequestType};
+use crate::openfinex::openfinex_types::{RequestId, RequestType};
 use crate::openfinex::request_builder::OpenFinexRequestBuilder;
 use crate::openfinex::string_serialization::{
     market_id_to_request_string, market_type_to_request_string, order_side_to_request_string,
     order_type_to_request_string, order_uuid_to_request_string, user_id_to_request_string,
 };
-use alloc::sync::Arc;
 use log::*;
-use polkadex_sgx_primitives::types::{CancelOrder, Order, PriceAndQuantityType};
+use polkadex_sgx_primitives::types::{CancelOrder, Order};
 
 /// implementation of the OpenFinex API
 pub struct OpenFinexApiImpl {
@@ -104,11 +103,11 @@ impl OpenFinexApi for OpenFinexApiImpl {
             .map_err(|e| OpenFinexApiError::WebSocketError(format!("{:?}", e)))
     }
 
-    fn withdraw_funds(&self, request_id: RequestId) -> OpenFinexApiResult<()> {
+    fn withdraw_funds(&self, _request_id: RequestId) -> OpenFinexApiResult<()> {
         todo!()
     }
 
-    fn deposit_funds(&self, request_id: RequestId) -> OpenFinexApiResult<()> {
+    fn deposit_funds(&self, _request_id: RequestId) -> OpenFinexApiResult<()> {
         todo!()
     }
 }

--- a/enclave/src/openfinex/openfinex_types.rs
+++ b/enclave/src/openfinex/openfinex_types.rs
@@ -33,6 +33,7 @@ pub enum RequestType {
     CreateOrder,
     CancelOrder,
     Subscribe,
+    GetMarkets,
 }
 
 impl alloc::fmt::Display for RequestType {
@@ -47,6 +48,7 @@ impl RequestType {
     const CREATE_ORDER_STR: &'static str = "admin_create_order";
     const CANCEL_ORDER_STR: &'static str = "admin_cancel_order";
     const SUBSCRIBE_EVENTS_STR: &'static str = "subscribe";
+    const GET_MARKETS_STR: &'static str = "get_markets";
 
     pub fn to_request_string(&self) -> String {
         match &self {
@@ -55,6 +57,7 @@ impl RequestType {
             RequestType::CreateOrder => String::from(RequestType::CREATE_ORDER_STR),
             RequestType::CancelOrder => String::from(RequestType::CANCEL_ORDER_STR),
             RequestType::Subscribe => String::from(RequestType::SUBSCRIBE_EVENTS_STR),
+            RequestType::GetMarkets => String::from(RequestType::GET_MARKETS_STR),
         }
     }
 
@@ -65,6 +68,7 @@ impl RequestType {
             RequestType::CREATE_ORDER_STR => Ok(RequestType::CreateOrder),
             RequestType::CANCEL_ORDER_STR => Ok(RequestType::CancelOrder),
             RequestType::SUBSCRIBE_EVENTS_STR => Ok(RequestType::Subscribe),
+            RequestType::GET_MARKETS_STR => Ok(RequestType::GetMarkets),
             _ => Err(OpenFinexApiError::ResponseParsingError(format!(
                 "invalid method string {}",
                 input

--- a/enclave/src/openfinex/request_builder.rs
+++ b/enclave/src/openfinex/request_builder.rs
@@ -17,10 +17,8 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 pub extern crate alloc;
-use crate::openfinex::openfinex_types::{OpenFinexDecimal, Preamble, RequestId, RequestType};
-use crate::openfinex::request_id_generator::RequestIdGenerator;
-use alloc::{string::String, string::ToString, sync::Arc, vec::Vec};
-use polkadex_sgx_primitives::types::PriceAndQuantityType;
+use crate::openfinex::openfinex_types::{Preamble, RequestId, RequestType};
+use alloc::{string::String, string::ToString, vec::Vec};
 
 #[derive(Debug, Clone)]
 pub struct OpenFinexRequest {

--- a/enclave/src/openfinex/response_object_mapper.rs
+++ b/enclave/src/openfinex/response_object_mapper.rs
@@ -19,16 +19,12 @@
 pub extern crate alloc;
 use crate::openfinex::fixed_point_number_converter::FixedPointNumberConverter;
 use crate::openfinex::openfinex_api::{OpenFinexApiError, OpenFinexApiResult};
-use crate::openfinex::openfinex_types::{
-    OpenFinexDecimal, RequestId, RequestType, ResponseInteger,
-};
+use crate::openfinex::openfinex_types::{RequestId, RequestType, ResponseInteger};
 use crate::openfinex::response_parser::{
     ParameterItem, ParameterNode, ParsedResponse, ResponseMethod,
 };
-use crate::openfinex::string_serialization::{
-    string_to_market_id, string_to_order_side, string_to_order_state, string_to_order_type,
-};
-use alloc::{string::String, vec::Vec};
+use crate::openfinex::string_serialization::OpenFinexResponseDeserializer;
+use alloc::{string::String, sync::Arc, vec::Vec};
 use codec::Encode;
 use core::iter::Peekable;
 use polkadex_sgx_primitives::types::{OrderUUID, OrderUpdate, PriceAndQuantityType, TradeEvent};
@@ -49,6 +45,7 @@ pub enum RequestResponse {
     WithdrawFunds(WithdrawResponse),
     CreateOrder(CreateOrderResponse),
     Subscription(SubscriptionResponse),
+    GetMarkets(GetMarketsResponse),
 }
 
 /// Deposit funds response
@@ -76,6 +73,12 @@ pub struct SubscriptionResponse {
     pub subscribed_events: Vec<String>,
 }
 
+/// Response to requesting markets information
+#[derive(Debug, Clone, PartialEq)]
+pub struct GetMarketsResponse {
+    pub json_content: Vec<String>, // strings containing JSON objects
+}
+
 pub trait OpenFinexResponseObjectMapper {
     fn map_to_response_object(
         &self,
@@ -83,7 +86,9 @@ pub trait OpenFinexResponseObjectMapper {
     ) -> OpenFinexApiResult<OpenFinexResponse>;
 }
 
-pub struct ResponseObjectMapper {}
+pub struct ResponseObjectMapper {
+    string_deserializer: Arc<dyn OpenFinexResponseDeserializer>,
+}
 
 impl OpenFinexResponseObjectMapper for ResponseObjectMapper {
     fn map_to_response_object(
@@ -93,20 +98,23 @@ impl OpenFinexResponseObjectMapper for ResponseObjectMapper {
         match &parsed_response.response_method {
             ResponseMethod::Error(s) => Ok(OpenFinexResponse::Error(s.clone())),
             ResponseMethod::FromRequestMethod(rt, ri) => {
-                ResponseObjectMapper::map_request_response(rt, ri, &parsed_response.parameters)
+                self.map_request_response(rt, ri, &parsed_response.parameters)
             }
-            ResponseMethod::TradeEvent => {
-                ResponseObjectMapper::map_trade_event(&parsed_response.parameters)
-            }
-            ResponseMethod::OrderUpdate => {
-                ResponseObjectMapper::map_order_update(&parsed_response.parameters)
-            }
+            ResponseMethod::TradeEvent => self.map_trade_event(&parsed_response.parameters),
+            ResponseMethod::OrderUpdate => self.map_order_update(&parsed_response.parameters),
         }
     }
 }
 
 impl ResponseObjectMapper {
+    pub fn new(string_deserializer: Arc<dyn OpenFinexResponseDeserializer>) -> Self {
+        ResponseObjectMapper {
+            string_deserializer,
+        }
+    }
+
     fn map_request_response(
+        &self,
         request_type: &RequestType,
         request_id: &RequestId,
         parameters: &Vec<ParameterNode>,
@@ -150,6 +158,15 @@ impl ResponseObjectMapper {
                     *request_id,
                 ))
             }
+            RequestType::GetMarkets => {
+                let json_string_objects = get_next_items(&mut param_iter, &extract_json_from_item)?;
+                Ok(OpenFinexResponse::RequestResponse(
+                    RequestResponse::GetMarkets(GetMarketsResponse {
+                        json_content: json_string_objects,
+                    }),
+                    *request_id,
+                ))
+            }
             _ => Err(OpenFinexApiError::ResponseParsingError(format!(
                 "Unknown or unsupported request type ({}), cannot map to response",
                 request_type
@@ -157,7 +174,10 @@ impl ResponseObjectMapper {
         }
     }
 
-    fn map_trade_event(parameters: &Vec<ParameterNode>) -> OpenFinexApiResult<OpenFinexResponse> {
+    fn map_trade_event(
+        &self,
+        parameters: &Vec<ParameterNode>,
+    ) -> OpenFinexApiResult<OpenFinexResponse> {
         let mut param_iter = parameters.iter().peekable();
 
         let market_id_str = get_next_single_item(&mut param_iter, &extract_string_from_item)?;
@@ -182,10 +202,14 @@ impl ResponseObjectMapper {
             get_next_single_item(&mut param_iter, &extract_string_from_item)?;
         let timestamp = get_next_single_item(&mut param_iter, &extract_integer_from_item)?;
 
-        let market_id = string_to_market_id(&market_id_str)
+        let market_id = self
+            .string_deserializer
+            .string_to_market_id(&market_id_str)
             .map_err(|e| OpenFinexApiError::ResponseParsingError(e))?;
 
-        let maker_side = string_to_order_side(&maker_order_side_str)
+        let maker_side = self
+            .string_deserializer
+            .string_to_order_side(&maker_order_side_str)
             .map_err(|e| OpenFinexApiError::ResponseParsingError(e))?;
 
         Ok(OpenFinexResponse::TradeEvent(TradeEvent {
@@ -203,7 +227,10 @@ impl ResponseObjectMapper {
         }))
     }
 
-    fn map_order_update(parameters: &Vec<ParameterNode>) -> OpenFinexApiResult<OpenFinexResponse> {
+    fn map_order_update(
+        &self,
+        parameters: &Vec<ParameterNode>,
+    ) -> OpenFinexApiResult<OpenFinexResponse> {
         let mut param_iter = parameters.iter().peekable();
 
         let _user_identifier = get_next_single_item(&mut param_iter, &extract_string_from_item)?;
@@ -224,16 +251,24 @@ impl ResponseObjectMapper {
         let trades_count = get_next_single_item(&mut param_iter, &extract_integer_from_item)?;
         let timestamp = get_next_single_item(&mut param_iter, &extract_integer_from_item)?;
 
-        let market_id = string_to_market_id(&market_id_str)
+        let market_id = self
+            .string_deserializer
+            .string_to_market_id(&market_id_str)
             .map_err(|e| OpenFinexApiError::ResponseParsingError(e))?;
 
-        let order_side = string_to_order_side(&order_side_str)
+        let order_side = self
+            .string_deserializer
+            .string_to_order_side(&order_side_str)
             .map_err(|e| OpenFinexApiError::ResponseParsingError(e))?;
 
-        let order_type = string_to_order_type(&order_type_str)
+        let order_type = self
+            .string_deserializer
+            .string_to_order_type(&order_type_str)
             .map_err(|e| OpenFinexApiError::ResponseParsingError(e))?;
 
-        let order_state = string_to_order_state(&order_state_str)
+        let order_state = self
+            .string_deserializer
+            .string_to_order_state(&order_state_str)
             .map_err(|e| OpenFinexApiError::ResponseParsingError(e))?;
 
         Ok(OpenFinexResponse::OrderUpdate(OrderUpdate {
@@ -292,6 +327,33 @@ fn get_next_item_list<'a, T: Iterator<Item = &'a ParameterNode>, R>(
     }
 }
 
+/// get as many items that match the extractor in a row
+fn get_next_items<'a, T: Iterator<Item = &'a ParameterNode>, R>(
+    iter: &mut Peekable<T>,
+    item_extractor: &dyn Fn(&ParameterItem) -> OpenFinexApiResult<R>,
+) -> OpenFinexApiResult<Vec<R>> {
+    let mut matched_items = Vec::<R>::new();
+    while let Some(&p) = iter.peek() {
+        let parameter_item = match extract_single_parameter_from_node(p) {
+            Ok(p) => p,
+            Err(_) => {
+                break;
+            }
+        };
+
+        match (item_extractor)(parameter_item) {
+            Ok(r) => {
+                matched_items.push(r);
+                iter.next();
+            }
+            Err(_) => {
+                break;
+            }
+        }
+    }
+    Ok(matched_items)
+}
+
 fn extract_single_parameter_from_node(node: &ParameterNode) -> OpenFinexApiResult<&ParameterItem> {
     match node {
         ParameterNode::SingleParameter(i) => Ok(i),
@@ -322,6 +384,16 @@ fn extract_string_from_item(item: &ParameterItem) -> OpenFinexApiResult<String> 
     }
 }
 
+fn extract_json_from_item(item: &ParameterItem) -> OpenFinexApiResult<String> {
+    match item {
+        ParameterItem::Json(s) => Ok(s.clone()),
+        _ => Err(OpenFinexApiError::ResponseParsingError(format!(
+            "Expected a JSON string parameter, but found {}",
+            item
+        ))),
+    }
+}
+
 fn extract_encoded_string_from_item(item: &ParameterItem) -> OpenFinexApiResult<Vec<u8>> {
     let item_as_string = extract_string_from_item(item)?;
     Ok(item_as_string.encode())
@@ -333,9 +405,9 @@ fn extract_decimal_from_item(item: &ParameterItem) -> OpenFinexApiResult<PriceAn
 
         // decimals in the response 'should' (according to OpenWare) always be wrapped in a string
         // so if we encounter a 'naked' number, this must be an error
-        ParameterItem::Number(n) => Err(OpenFinexApiError::ResponseParsingError(format!(
+        _ => Err(OpenFinexApiError::ResponseParsingError(format!(
             "Expected a decimal string parameter, but found {}",
-            n
+            item
         ))),
     }
 }
@@ -349,5 +421,9 @@ fn extract_integer_from_item(item: &ParameterItem) -> OpenFinexApiResult<Respons
             ))
         }),
         ParameterItem::Number(n) => Ok(*n),
+        _ => Err(OpenFinexApiError::ResponseParsingError(format!(
+            "Expected an integer parameter, but found {}",
+            item
+        ))),
     }
 }

--- a/enclave/src/openfinex/tests/market_repo_tests.rs
+++ b/enclave/src/openfinex/tests/market_repo_tests.rs
@@ -1,0 +1,67 @@
+// This file is part of Polkadex.
+
+// Copyright (C) 2020-2021 Polkadex oü.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::openfinex::market_repo::{MarketRepository, MarketsRequestCallback};
+use crate::polkadex_cache::cache_api::{CacheProvider, CacheResult};
+use crate::polkadex_cache::market_cache::MarketCache;
+use log::*;
+use std::string::ToString;
+use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::{Arc, SgxMutex};
+
+struct MarketCacheProviderMock {
+    initial_market_cache: MarketCache,
+    cache_ptr: AtomicPtr<()>,
+}
+
+impl MarketCacheProviderMock {}
+
+impl CacheProvider<MarketCache> for MarketCacheProviderMock {
+    fn initialize(&self) {
+        let cache_storage_ptr = Arc::new(SgxMutex::new(self.initial_market_cache.clone()));
+        let cache_ptr = Arc::into_raw(cache_storage_ptr);
+        self.cache_ptr.store(cache_ptr as *mut (), Ordering::SeqCst);
+    }
+
+    fn load(&self) -> CacheResult<&'static SgxMutex<MarketCache>> {
+        let ptr = self.cache_ptr.load(Ordering::SeqCst) as *mut SgxMutex<MarketCache>;
+        if ptr.is_null() {
+            error!("Could not load cache");
+            return Err(());
+        } else {
+            Ok(unsafe { &*ptr })
+        }
+    }
+}
+
+pub fn update_markets_from_json_strings() {
+    let cache_provider = Arc::new(MarketCacheProviderMock {
+        initial_market_cache: MarketCache::new(),
+        cache_ptr: AtomicPtr::new(0 as *mut ()),
+    });
+    cache_provider.initialize();
+
+    let market_repo = MarketRepository::new(cache_provider);
+
+    let json_strings = vec![
+        r#"{"id":"btcusd","name":"BTC/USD","base_unit":"btc","quote_unit":"usd","state":"enabled","amount_precision":4,"price_precision":4,"min_price":"0.0001","max_price":"0","min_amount":"0.0001","position":100,"filters":[]}"#.to_string(),
+        r#"{"id":"trsteth","name":"TRST/ETH","base_unit":"trst","quote_unit":"eth","state":"enabled","amount_precision":4,"price_precision":4,"min_price":"0.0001","max_price":"0","min_amount":"0.0001","position":105,"filters":[]}"#.to_string()
+    ];
+
+    assert!(market_repo.update_markets(1, &json_strings).is_ok());
+}

--- a/enclave/src/openfinex/tests/mod.rs
+++ b/enclave/src/openfinex/tests/mod.rs
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+pub mod market_repo_tests;
 pub mod response_handler_tests;
 pub mod response_object_mapper_tests;
 pub mod response_parser_tests;

--- a/enclave/src/openfinex/tests/response_handler_tests.rs
+++ b/enclave/src/openfinex/tests/response_handler_tests.rs
@@ -18,28 +18,40 @@
 
 pub extern crate alloc;
 
+use crate::openfinex::market_repo::{MarketRepositoryError, MarketsRequestCallback};
 use crate::openfinex::openfinex_api::OpenFinexApiResult;
 use crate::openfinex::response_handler::PolkadexResponseHandler;
 use crate::openfinex::response_object_mapper::{OpenFinexResponse, OpenFinexResponseObjectMapper};
 use crate::openfinex::response_parser::{ParsedResponse, ResponseParser};
 use crate::polkadex_gateway::{GatewayError, PolkaDexGatewayCallback};
-use alloc::{string::String, sync::Arc};
+use alloc::{string::String, sync::Arc, vec::Vec};
 use polkadex_sgx_primitives::types::OrderUUID;
 
 struct GatewayCallBackMock;
 impl PolkaDexGatewayCallback for GatewayCallBackMock {
-    fn process_cancel_order(&self, order_uuid: OrderUUID) -> Result<(), GatewayError> {
+    fn process_cancel_order(&self, _order_uuid: OrderUUID) -> Result<(), GatewayError> {
         todo!()
     }
 
-    fn process_create_order(&self, order_uuid: OrderUUID) -> Result<(), GatewayError> {
+    fn process_create_order(&self, _order_uuid: OrderUUID) -> Result<(), GatewayError> {
+        todo!()
+    }
+}
+
+struct MarketsRequestCallbackMock;
+impl MarketsRequestCallback for MarketsRequestCallbackMock {
+    fn update_markets(
+        &self,
+        _request_id: u128,
+        _json_strings: &Vec<String>,
+    ) -> Result<(), MarketRepositoryError> {
         todo!()
     }
 }
 
 struct ResponseParserMock;
 impl ResponseParser for ResponseParserMock {
-    fn parse_response_string(&self, response: String) -> OpenFinexApiResult<ParsedResponse> {
+    fn parse_response_string(&self, _response: String) -> OpenFinexApiResult<ParsedResponse> {
         todo!()
     }
 }
@@ -48,7 +60,7 @@ struct ResponseObjectMapperMock;
 impl OpenFinexResponseObjectMapper for ResponseObjectMapperMock {
     fn map_to_response_object(
         &self,
-        parsed_response: &ParsedResponse,
+        _parsed_response: &ParsedResponse,
     ) -> OpenFinexApiResult<OpenFinexResponse> {
         todo!()
     }
@@ -57,7 +69,12 @@ impl OpenFinexResponseObjectMapper for ResponseObjectMapperMock {
 fn create_response_handler() -> PolkadexResponseHandler {
     PolkadexResponseHandler::new(
         Arc::new(GatewayCallBackMock {}),
+        Arc::new(MarketsRequestCallbackMock {}),
         Arc::new(ResponseParserMock {}),
         Arc::new(ResponseObjectMapperMock {}),
     )
+}
+
+pub fn handle_request_response() {
+    let _response_handler = create_response_handler();
 }

--- a/enclave/src/openfinex/tests/response_parser_tests.rs
+++ b/enclave/src/openfinex/tests/response_parser_tests.rs
@@ -17,13 +17,11 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 pub extern crate alloc;
-use crate::openfinex::openfinex_api::OpenFinexApiError::ResponseParsingError;
-use crate::openfinex::openfinex_api::{OpenFinexApiError, OpenFinexApiResult};
-use crate::openfinex::openfinex_types::{Preamble, RequestId, RequestType};
+use crate::openfinex::openfinex_types::RequestType;
 use crate::openfinex::response_parser::{
     ParameterNode, ResponseMethod, ResponseParser, TcpResponseParser,
 };
-use alloc::{string::String, string::ToString, vec::Vec};
+use alloc::{string::String, string::ToString};
 
 pub fn given_valid_create_order_response_then_parse_items() {
     let response_string = "[2,42,\"admin_create_order\",[\"1245-2345-6798-123123\"]]".to_string();
@@ -37,6 +35,20 @@ pub fn given_valid_create_order_response_then_parse_items() {
         ResponseMethod::FromRequestMethod(RequestType::CreateOrder, 42)
     );
     assert_eq!(parsed_response.parameters.len(), 1);
+}
+
+pub fn given_valid_get_markets_response_then_parse_items() {
+    let response_string = (r#"[2,1,"get_markets",[{"id":"btcusd","name":"BTC/USD","base_unit":"btc","quote_unit":"usd","state":"enabled","amount_precision":4,"price_precision":4,"min_price":"0.0001","max_price":"0","min_amount":"0.0001","position":100,"filters":[]},{"id":"trsteth","name":"TRST/ETH","base_unit":"trst","quote_unit":"eth","state":"enabled","amount_precision":4,"price_precision":4,"min_price":"0.0001","max_price":"0","min_amount":"0.0001","position":105,"filters":[]}]]"#).to_string();
+
+    let parser = TcpResponseParser {};
+    let parsed_response = parser.parse_response_string(response_string).unwrap();
+
+    assert_eq!(parsed_response.response_preamble, 2);
+    assert_eq!(
+        parsed_response.response_method,
+        ResponseMethod::FromRequestMethod(RequestType::GetMarkets, 1)
+    );
+    assert_eq!(parsed_response.parameters.len(), 2);
 }
 
 pub fn given_valid_error_response_then_parse_items() {

--- a/enclave/src/polkadex_cache/cache_api.rs
+++ b/enclave/src/polkadex_cache/cache_api.rs
@@ -16,19 +16,108 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-
-use std::sync::SgxMutex;
 pub use crate::openfinex::openfinex_types::RequestId;
-
+use log::*;
+use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::Arc;
+use std::sync::SgxMutex;
 
 /// result type definition using the OpenFinexApiError$
 /// -> This might be sensible to change to custom error in the future
 /// But for now only two tpyes of errors are necessary..
 pub type CacheResult<T> = core::result::Result<T, ()>;
 
+/// Generic cache provider, requires to be initialized before load
+pub trait CacheProvider<T> {
+    fn initialize(&self);
+
+    fn load(&self) -> CacheResult<&'static SgxMutex<T>>;
+}
+
+/// A static cache provider, meaning it uses global state to store the cache,
+/// stored in an atomic pointer, guarded by an SGX mutex
+pub struct StaticCacheProvider<T: 'static> {
+    initial_item: &'static dyn Fn() -> T,
+    static_cache_ptr: &'static AtomicPtr<()>,
+}
+
+impl<T> CacheProvider<T> for StaticCacheProvider<T> {
+    fn initialize(&self) {
+        let initial = (self.initial_item)();
+        let cache_storage_ptr = Arc::new(SgxMutex::new(initial));
+        let cache_ptr = Arc::into_raw(cache_storage_ptr);
+        self.static_cache_ptr
+            .store(cache_ptr as *mut (), Ordering::SeqCst);
+    }
+
+    fn load(&self) -> CacheResult<&'static SgxMutex<T>> {
+        let ptr = self.static_cache_ptr.load(Ordering::SeqCst) as *mut SgxMutex<T>;
+        if ptr.is_null() {
+            error!("Could not load cache");
+            return Err(());
+        } else {
+            Ok(unsafe { &*ptr })
+        }
+    }
+}
+
+impl<T> StaticCacheProvider<T> {
+    /// constructor taking a generator function for the initial item
+    /// and a generic atomic pointer to where the cache should be stored
+    pub fn new(
+        initial_item: &'static dyn Fn() -> T,
+        static_cache_ptr: &'static AtomicPtr<()>,
+    ) -> Self {
+        StaticCacheProvider {
+            initial_item,
+            static_cache_ptr,
+        }
+    }
+}
+
+/// A cache provider that stores the cache in local state, not a global static pointer
+pub struct LocalCacheProvider<T: 'static> {
+    initial_cache: &'static dyn Fn() -> T,
+    cache_ptr: AtomicPtr<()>,
+}
+
+impl<T> LocalCacheProvider<T> {
+    /// constructor taking a generator function for the initial item
+    /// and a generic atomic pointer to where the cache should be stored
+    pub fn new(initial_cache: &'static dyn Fn() -> T) -> Self {
+        let cache_provider = LocalCacheProvider {
+            initial_cache,
+            cache_ptr: AtomicPtr::new(0 as *mut ()),
+        };
+
+        cache_provider.initialize();
+
+        cache_provider
+    }
+}
+
+impl<T> CacheProvider<T> for LocalCacheProvider<T> {
+    fn initialize(&self) {
+        let initial_cache = (self.initial_cache)();
+        let cache_storage_ptr = Arc::new(SgxMutex::new(initial_cache));
+        let cache_ptr = Arc::into_raw(cache_storage_ptr);
+        self.cache_ptr.store(cache_ptr as *mut (), Ordering::SeqCst);
+    }
+
+    fn load(&self) -> CacheResult<&'static SgxMutex<T>> {
+        let ptr = self.cache_ptr.load(Ordering::SeqCst) as *mut SgxMutex<T>;
+        if ptr.is_null() {
+            error!("Could not load cache");
+            return Err(());
+        } else {
+            Ok(unsafe { &*ptr })
+        }
+    }
+}
 
 /// Static Storage Interaction trait - used to initialize and load the storage to be
 /// used from different threads.
+/// @deprecated -> move all implementations to CacheProvider<T> or StaticCacheProvider<T> respectively
 pub trait StaticStorageApi {
     /// initializes the storage within a static pointer to be usable from different threads
     fn initialize();

--- a/enclave/src/polkadex_cache/cancel_order_cache.rs
+++ b/enclave/src/polkadex_cache/cancel_order_cache.rs
@@ -16,24 +16,24 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::polkadex_cache::cache_api::{CacheResult, RequestId, StaticStorageApi};
 use log::*;
 use polkadex_sgx_primitives::types::OrderUUID;
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicPtr, Ordering};
 use std::sync::{Arc, SgxMutex};
-use crate::polkadex_cache::cache_api::{RequestId, StaticStorageApi, CacheResult};
 
 static CANCEL_ORDER_CACHE: AtomicPtr<()> = AtomicPtr::new(0 as *mut ());
 
 #[derive(Debug)]
 pub struct CancelOrderCache {
-    /// The set of chached order uuids
+    /// The set of cached order uuids
     order_uuids: HashSet<OrderUUID>,
     /// Nonce / request_id (do wee need this in the cancel_order?)
     request_id: RequestId,
 }
 
-impl Default for CancelOrderCache{
+impl Default for CancelOrderCache {
     fn default() -> Self {
         CancelOrderCache {
             order_uuids: Default::default(),
@@ -41,7 +41,6 @@ impl Default for CancelOrderCache{
         }
     }
 }
-
 
 impl StaticStorageApi for CancelOrderCache {
     fn initialize() {
@@ -97,12 +96,9 @@ impl CancelOrderCache {
     }
 }
 
-
-
 pub mod tests {
     use super::*;
     use codec::Encode;
-
 
     pub fn test_initialize_and_lock_storage() {
         // given
@@ -118,10 +114,7 @@ pub mod tests {
     pub fn test_insert_order_and_increment() {
         // given
         CancelOrderCache::initialize();
-        let mut cache = CancelOrderCache::load()
-            .unwrap()
-            .lock()
-            .unwrap();
+        let mut cache = CancelOrderCache::load().unwrap().lock().unwrap();
         let order_uuid: OrderUUID = "hello_world".encode();
         assert_eq!(cache.request_id(), 0);
 
@@ -137,13 +130,9 @@ pub mod tests {
     /// removes the second, but leaves the first
     /// then checks if second was really removed
     pub fn test_remove_order() {
-
         // given
         CancelOrderCache::initialize();
-        let mut cache = CancelOrderCache::load()
-            .unwrap()
-            .lock()
-            .unwrap();
+        let mut cache = CancelOrderCache::load().unwrap().lock().unwrap();
         let order_uuid_0: OrderUUID = "hello_world".encode();
         let order_uuid_1: OrderUUID = "hello_world_two".encode();
         let order_0_id = cache.request_id();
@@ -175,10 +164,7 @@ pub mod tests {
             CancelOrderCache::initialize();
         }
         {
-            let mut cache = CancelOrderCache::load()
-                .unwrap()
-                .lock()
-                .unwrap();
+            let mut cache = CancelOrderCache::load().unwrap().lock().unwrap();
             let order_0_id = cache.request_id();
             assert_eq!(order_0_id, 0);
             assert!(cache.insert_order(order_uuid_0.clone()));
@@ -189,22 +175,14 @@ pub mod tests {
 
         // when
         {
-            let mut cache = CancelOrderCache::load()
-                .unwrap()
-                .lock()
-                .unwrap();
+            let mut cache = CancelOrderCache::load().unwrap().lock().unwrap();
             assert!(cache.remove_order(&order_uuid_1));
         }
 
-
         // then
-        let cache = CancelOrderCache::load()
-            .unwrap()
-            .lock()
-            .unwrap();
+        let cache = CancelOrderCache::load().unwrap().lock().unwrap();
         assert!(!cache.contains(&order_uuid_1));
         assert!(cache.contains(&order_uuid_0));
         assert_eq!(cache.request_id(), 2);
     }
-
 }

--- a/enclave/src/polkadex_cache/create_order_cache.rs
+++ b/enclave/src/polkadex_cache/create_order_cache.rs
@@ -16,28 +16,24 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::polkadex_cache::cache_api::{CacheResult, RequestId, StaticStorageApi};
 use log::*;
 use polkadex_sgx_primitives::types::Order;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicPtr, Ordering};
 use std::sync::{Arc, SgxMutex};
-use crate::polkadex_cache::cache_api::{RequestId, StaticStorageApi, CacheResult};
-
-use codec::{Encode, Decode};
-use std::string::{String, ToString};
 
 static CREATE_ORDER_CACHE: AtomicPtr<()> = AtomicPtr::new(0 as *mut ());
 
-
 #[derive(Debug)]
 pub struct CreateOrderCache {
-    /// The set of chached order uuids
+    /// The set of cached order uuids
     order_map: HashMap<RequestId, Order>,
     /// Nonce / request_id
     request_id: RequestId,
 }
 
-impl Default for CreateOrderCache{
+impl Default for CreateOrderCache {
     fn default() -> Self {
         CreateOrderCache {
             order_map: Default::default(),
@@ -68,7 +64,6 @@ impl StaticStorageApi for CreateOrderCache {
     }
 }
 
-
 impl CreateOrderCache {
     /// removes the given order from the cache. Returns the value of
     /// the given key if previously present
@@ -79,12 +74,12 @@ impl CreateOrderCache {
     /// inserts an order to the set and increments the request id.
     /// Returns the request_id it order was stored at
     pub fn insert_order(&mut self, order: Order) -> RequestId {
-        let current_requst_id = self.request_id;
+        let current_request_id = self.request_id;
         if let Some(e) = self.order_map.insert(self.request_id, order) {
             error!("A cache value was unexpectedly overwirrten: {:?}", e);
         }
         self.increment_request_id();
-        current_requst_id
+        current_request_id
     }
 
     pub fn request_id(&self) -> RequestId {
@@ -98,11 +93,9 @@ impl CreateOrderCache {
     }
 }
 
-
 pub mod tests {
     use super::*;
     use crate::test_orderbook_storage;
-
 
     pub fn test_initialize_and_lock_storage() {
         // given
@@ -118,10 +111,7 @@ pub mod tests {
     pub fn test_insert_order_and_increment() {
         // given
         CreateOrderCache::initialize();
-        let mut cache = CreateOrderCache::load()
-            .unwrap()
-            .lock()
-            .unwrap();
+        let mut cache = CreateOrderCache::load().unwrap().lock().unwrap();
         let orders = test_orderbook_storage::get_dummy_orders();
         assert_eq!(cache.request_id(), 0);
 
@@ -136,10 +126,7 @@ pub mod tests {
     pub fn test_remove_order() {
         // given
         CreateOrderCache::initialize();
-        let mut cache = CreateOrderCache::load()
-            .unwrap()
-            .lock()
-            .unwrap();
+        let mut cache = CreateOrderCache::load().unwrap().lock().unwrap();
         let orders = test_orderbook_storage::get_dummy_orders();
         let order_0_id = cache.request_id();
         assert_eq!(order_0_id, 0);
@@ -167,10 +154,7 @@ pub mod tests {
             CreateOrderCache::initialize();
         }
         {
-            let mut cache = CreateOrderCache::load()
-                .unwrap()
-                .lock()
-                .unwrap();
+            let mut cache = CreateOrderCache::load().unwrap().lock().unwrap();
             let order_0_id = cache.request_id();
             assert_eq!(order_0_id, 0);
             let id_0 = cache.insert_order(orders[0].clone());
@@ -183,10 +167,7 @@ pub mod tests {
 
         // when
         {
-            let mut cache = CreateOrderCache::load()
-                .unwrap()
-                .lock()
-                .unwrap();
+            let mut cache = CreateOrderCache::load().unwrap().lock().unwrap();
             let order_1 = cache.remove_order(&1).unwrap();
             let none = cache.remove_order(&1);
 
@@ -194,17 +175,12 @@ pub mod tests {
             assert_eq!(order_1, orders[1]);
         }
 
-
         // then
-        let mut cache = CreateOrderCache::load()
-            .unwrap()
-            .lock()
-            .unwrap();
+        let mut cache = CreateOrderCache::load().unwrap().lock().unwrap();
         let order_1 = cache.remove_order(&1);
         assert!(order_1.is_none());
         let order_0 = cache.remove_order(&0).unwrap();
         assert_eq!(order_0, orders[0]);
         assert_eq!(cache.request_id(), 2);
     }
-
 }

--- a/enclave/src/polkadex_cache/market_cache.rs
+++ b/enclave/src/polkadex_cache/market_cache.rs
@@ -1,0 +1,177 @@
+// This file is part of Polkadex.
+
+// Copyright (C) 2020-2021 Polkadex oü.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::openfinex::market::Market;
+use crate::openfinex::openfinex_types::RequestId;
+use crate::polkadex_cache::cache_api::LocalCacheProvider;
+use log::*;
+use std::collections::HashMap;
+use std::string::String;
+use std::vec::Vec;
+
+pub struct LocalMarketCacheFactory {}
+
+/// factory for a local cache of MarketCache
+impl LocalMarketCacheFactory {
+    pub fn create() -> LocalCacheProvider<MarketCache> {
+        LocalCacheProvider::<MarketCache>::new(&|| MarketCache::new())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MarketCache {
+    /// The set of cached markets
+    markets: HashMap<String, Market>,
+
+    /// current request ID - increments after receiving a markets update
+    request_id: RequestId,
+}
+
+impl Default for MarketCache {
+    fn default() -> Self {
+        MarketCache {
+            markets: Default::default(),
+            request_id: 0,
+        }
+    }
+}
+
+impl MarketCache {
+    /// constructor
+    pub fn new() -> MarketCache {
+        MarketCache {
+            markets: HashMap::new(),
+            request_id: 1,
+        }
+    }
+
+    /// set markets in the cache, replacing any existing ones
+    /// checks if the request ids match, otherwise do nothing
+    pub fn set_markets(&mut self, request_id: RequestId, markets: Vec<Market>) {
+        if self.request_id != request_id {
+            warn!("Attempting to update markets, but request ID does not match; ignoring attempt");
+            return;
+        }
+
+        self.markets.clear();
+        for market in markets {
+            self.markets.insert(market.id.clone(), market);
+        }
+
+        self.increment_request_id();
+    }
+
+    /// gets a market by id
+    pub fn get_market(&self, id: &String) -> Option<&Market> {
+        self.markets.get(id)
+    }
+
+    pub fn request_id(&self) -> RequestId {
+        self.request_id
+    }
+}
+
+impl MarketCache {
+    fn increment_request_id(&mut self) {
+        self.request_id = self.request_id.wrapping_add(1)
+    }
+}
+
+pub mod tests {
+
+    use super::*;
+    use crate::openfinex::market::MarketState;
+    use std::string::ToString;
+
+    pub fn set_markets_with_valid_request_id() {
+        let markets = vec![
+            create_market("btcusd", "btc", "usd"),
+            create_market("usdbtc", "usd", "btc"),
+        ];
+
+        let mut market_cache = MarketCache {
+            markets: HashMap::new(),
+            request_id: 1,
+        };
+        market_cache.set_markets(market_cache.request_id(), markets.clone());
+
+        assert_eq!(2, market_cache.request_id());
+        assert_eq!(markets.len(), market_cache.markets.len());
+    }
+
+    pub fn set_markets_with_invalid_request_id() {
+        let markets = vec![create_market("example", "la", "di")];
+
+        let mut market_cache = MarketCache {
+            markets: HashMap::new(),
+            request_id: 1,
+        };
+        market_cache.set_markets(0, markets); // invalid/non-matching request id
+
+        assert_eq!(1, market_cache.request_id());
+        assert!(market_cache.markets.is_empty()); // still empty, because request ID didn-t match
+    }
+
+    pub fn set_markets_repeatedly_clears_previous() {
+        let markets = vec![create_market("market_id", "base", "quote")];
+
+        let mut market_cache = MarketCache {
+            markets: HashMap::new(),
+            request_id: 569,
+        };
+
+        market_cache.set_markets(market_cache.request_id(), markets);
+        market_cache.set_markets(market_cache.request_id(), vec![]);
+
+        assert_eq!(571, market_cache.request_id);
+        assert!(market_cache.markets.is_empty());
+    }
+
+    pub fn retrieve_previously_inserted_markets() {
+        let markets = vec![
+            create_market("btcusd", "btc", "usd"),
+            create_market("usdbtc", "usd", "btc"),
+            create_market("trsteth", "trst", "eth"),
+        ];
+
+        let mut market_cache = MarketCache {
+            markets: HashMap::new(),
+            request_id: 2345,
+        };
+
+        market_cache.set_markets(market_cache.request_id(), markets);
+
+        assert!(market_cache.get_market(&"btcusd".to_string()).is_some());
+        assert!(market_cache.get_market(&"trsteth".to_string()).is_some());
+        assert!(market_cache
+            .get_market(&"other_invalid".to_string())
+            .is_none());
+    }
+
+    fn create_market(id: &str, base_unit: &str, quote_unit: &str) -> Market {
+        Market {
+            id: String::from(id),
+            base_unit: String::from(base_unit),
+            quote_unit: String::from(quote_unit),
+            state: MarketState::enabled,
+            name: String::from(id),
+            amount_precision: 4,
+            price_precision: 4,
+        }
+    }
+}

--- a/enclave/src/polkadex_cache/mod.rs
+++ b/enclave/src/polkadex_cache/mod.rs
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+pub mod cache_api;
 pub mod cancel_order_cache;
 pub mod create_order_cache;
-pub mod cache_api;
+pub mod market_cache;

--- a/enclave/src/tests.rs
+++ b/enclave/src/tests.rs
@@ -86,6 +86,11 @@ pub extern "C" fn test_main_entrance() -> size_t {
         polkadex_cache::cancel_order_cache::tests::test_remove_order,
         polkadex_cache::cancel_order_cache::tests::test_reload_cache,
 
+        polkadex_cache::market_cache::tests::set_markets_with_valid_request_id,
+        polkadex_cache::market_cache::tests::set_markets_with_invalid_request_id,
+        polkadex_cache::market_cache::tests::set_markets_repeatedly_clears_previous,
+        polkadex_cache::market_cache::tests::retrieve_previously_inserted_markets,
+
         // Polkadex Gateway
         test_polkadex_gateway::initialize_storage, // This is not a test but initializes storage for the following tests
         test_polkadex_gateway::test_authenticate_user,
@@ -144,10 +149,16 @@ pub extern "C" fn test_main_entrance() -> size_t {
         openfinex::string_serialization::tests::test_map_order_type,
         openfinex::string_serialization::tests::test_map_order_state,
         openfinex::string_serialization::tests::test_map_market_id,
-        openfinex::response_lexer::tests::test_given_valid_delimited_string_then_return_result,
-        openfinex::response_lexer::tests::test_given_string_with_missing_delimiter_then_return_error,
-        openfinex::response_lexer::tests::test_given_valid_number_str_then_lex_correctly,
+        openfinex::market::tests::test_deserialize_market_usdbtc,
+        openfinex::market::tests::test_deserialize_market_trsteth,
+        openfinex::response_lexer::tests::given_valid_delimited_string_then_return_result,
+        openfinex::response_lexer::tests::given_string_with_missing_delimiter_then_return_error,
+        openfinex::response_lexer::tests::given_valid_number_str_then_lex_correctly,
         openfinex::response_lexer::tests::given_valid_response_string_then_return_lexed_items,
+        openfinex::response_lexer::tests::parse_openfinex_example_json_parameter_correctly,
+        openfinex::response_lexer::tests::parse_json_parameter_mixed_with_regular_parameters,
+        openfinex::response_lexer::tests::given_json_parameter_with_too_many_closing_braces_then_return_error,
+        openfinex::response_lexer::tests::given_json_parameter_with_missing_closing_braces_then_return_error,
         openfinex::tests::response_parser_tests::given_valid_create_order_response_then_parse_items,
         openfinex::tests::response_parser_tests::given_valid_error_response_then_parse_items,
         openfinex::tests::response_parser_tests::given_valid_response_with_nested_parameters_then_parse_items,
@@ -155,11 +166,15 @@ pub extern "C" fn test_main_entrance() -> size_t {
         openfinex::tests::response_parser_tests::given_valid_subscription_response_then_succeed,
         openfinex::tests::response_parser_tests::given_valid_order_update_response_then_succeed,
         openfinex::tests::response_parser_tests::given_valid_trade_events_response_then_succeed,
+        openfinex::tests::response_parser_tests::given_valid_get_markets_response_then_parse_items,
         openfinex::tests::response_object_mapper_tests::test_given_parsed_error_then_map_to_error_object,
         openfinex::tests::response_object_mapper_tests::test_subscribe_response,
         openfinex::tests::response_object_mapper_tests::test_create_order_response,
         openfinex::tests::response_object_mapper_tests::test_order_update_response,
         openfinex::tests::response_object_mapper_tests::test_trade_event_response,
+        openfinex::tests::response_object_mapper_tests::test_get_markets_response,
+        openfinex::tests::market_repo_tests::update_markets_from_json_strings,
+        openfinex::tests::response_handler_tests::handle_request_response,
 
         // RPC API tests
         rpc_call_encoder::tests::test_encoding_none_params_returns_ok,


### PR DESCRIPTION
As described in #105 , we request the market information from OpenFinex using the same WS-interface as for all other requests. The response is parsed, mapped and stored in a cache (MarketCache) that can be used when processing order and event responses to get the AssetIds based on the market id.

Closes #105 