### PR TITLE
Add User/Account IDs to `OrderUpdate` and `TradeEvent`

### DIFF
--- a/enclave/src/ss58check.rs
+++ b/enclave/src/ss58check.rs
@@ -16,7 +16,7 @@
 // limitations under the License.
 
 pub extern crate alloc;
-use alloc::string::String;
+use alloc::{fmt::Display, fmt::Formatter, fmt::Result as FormatResult, string::String};
 use base58::{FromBase58, ToBase58};
 use blake2_rfc::blake2b::{Blake2b, Blake2bResult};
 use core::convert::AsMut;
@@ -31,6 +31,12 @@ pub enum SS58CheckError {
     UnknownVersion,
     FormatNotAllowed,
     InvalidChecksum,
+}
+
+impl Display for SS58CheckError {
+    fn fmt(&self, f: &mut Formatter) -> FormatResult {
+        write!(f, "{:?}", self)
+    }
 }
 
 /// utility function to get the ss58check string representation for an AccountId32

--- a/enclave/src/test_polkadex_gateway.rs
+++ b/enclave/src/test_polkadex_gateway.rs
@@ -8,18 +8,18 @@ use sgx_tstd::vec::Vec;
 
 // Polkadex represents 1 Token as 10^^18 minimum possible units
 use crate::constants::UNIT;
+use crate::openfinex::openfinex_api::{OpenFinexApi, OpenFinexApiResult};
 use crate::polkadex::{add_main_account, create_in_memory_account_storage};
 use crate::polkadex_balance_storage::{
     create_in_memory_balance_storage, lock_storage_and_deposit, lock_storage_and_get_balances,
     lock_storage_and_initialize_balance,
 };
-use crate::polkadex_cache::cache_api::{StaticStorageApi, RequestId};
+use crate::polkadex_cache::cache_api::{RequestId, StaticStorageApi};
 use crate::polkadex_cache::create_order_cache::CreateOrderCache;
 use crate::polkadex_gateway::{
-    authenticate_user, initialize_polkadex_gateway, OpenfinexPolkaDexGateway,
-    process_cancel_order, process_create_order, settle_trade, GatewayError,
+    authenticate_user, initialize_polkadex_gateway, process_cancel_order, process_create_order,
+    settle_trade, GatewayError, OpenfinexPolkaDexGateway,
 };
-use crate::openfinex::openfinex_api::{OpenFinexApi, OpenFinexApiResult};
 use crate::polkadex_orderbook_storage::{
     create_in_memory_orderbook_storage, lock_storage_and_add_order,
     lock_storage_and_check_order_in_orderbook, lock_storage_and_get_order,
@@ -54,13 +54,10 @@ impl OpenFinexApi for OpenFinexApiMock {
     fn deposit_funds(&self, request_id: RequestId) -> OpenFinexApiResult<()> {
         Ok(())
     }
-
 }
 
 pub fn create_mock_gateway() -> OpenfinexPolkaDexGateway<OpenFinexApiMock> {
-    OpenfinexPolkaDexGateway::new(
-        OpenFinexApiMock::new()
-    )
+    OpenfinexPolkaDexGateway::new(OpenFinexApiMock::new())
 }
 
 pub fn initialize_storage() {
@@ -120,14 +117,20 @@ pub fn test_place_limit_buy_order() {
 
     setup(main.clone());
     check_balance(100 * UNIT, 0u128, main.clone(), AssetId::DOT).unwrap(); // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(main.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(main.clone(), None, new_order.clone())
+        .is_ok());
     check_balance(99 * UNIT, UNIT, main.clone(), AssetId::DOT).unwrap(); // Balance: DOT = (99,1) where (free,reserved)
     new_order.quantity = 100 * UNIT;
-    assert!(gateway.place_order(main.clone(), None, new_order.clone()).is_err());
+    assert!(gateway
+        .place_order(main.clone(), None, new_order.clone())
+        .is_err());
     check_balance(99 * UNIT, UNIT, main.clone(), AssetId::DOT).unwrap(); // Balance: DOT = (99,1) where (free,reserved)
     new_order.quantity = UNIT;
     new_order.price = Some(99 * UNIT);
-    assert!(gateway.place_order(main.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(main.clone(), None, new_order.clone())
+        .is_ok());
     check_balance(0u128, 100 * UNIT, main.clone(), AssetId::DOT).unwrap(); // Balance: DOT = (0,100) where (free,reserved)
     check_balance(100 * UNIT, 0u128, main.clone(), AssetId::POLKADEX).unwrap();
 }
@@ -150,14 +153,20 @@ pub fn test_place_limit_sell_order() {
 
     setup(main.clone());
     check_balance(100 * UNIT, 0u128, main.clone(), AssetId::POLKADEX).unwrap(); // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(main.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(main.clone(), None, new_order.clone())
+        .is_ok());
     check_balance(99 * UNIT, UNIT, main.clone(), AssetId::POLKADEX).unwrap(); // Balance: DOT = (99,1) where (free,reserved)
     new_order.quantity = 100 * UNIT;
-    assert!(gateway.place_order(main.clone(), None, new_order.clone()).is_err());
+    assert!(gateway
+        .place_order(main.clone(), None, new_order.clone())
+        .is_err());
     check_balance(99 * UNIT, UNIT, main.clone(), AssetId::POLKADEX).unwrap(); // Balance: DOT = (99,1) where (free,reserved)
     new_order.quantity = UNIT;
     new_order.price = Some(99 * UNIT);
-    assert!(gateway.place_order(main.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(main.clone(), None, new_order.clone())
+        .is_ok());
     check_balance(98 * UNIT, 2 * UNIT, main.clone(), AssetId::POLKADEX).unwrap(); // Balance: DOT = (0,100) where (free,reserved)
     check_balance(100 * UNIT, 0u128, main.clone(), AssetId::DOT).unwrap();
 }
@@ -180,13 +189,19 @@ pub fn test_place_market_buy_order() {
 
     setup(main.clone());
     check_balance(100 * UNIT, 0u128, main.clone(), AssetId::DOT).unwrap(); // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(main.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(main.clone(), None, new_order.clone())
+        .is_ok());
     check_balance(99 * UNIT, UNIT, main.clone(), AssetId::DOT).unwrap(); // Balance: DOT = (99,1) where (free,reserved)
     new_order.price = Some(100 * UNIT);
-    assert!(gateway.place_order(main.clone(), None, new_order.clone()).is_err());
+    assert!(gateway
+        .place_order(main.clone(), None, new_order.clone())
+        .is_err());
     check_balance(99 * UNIT, UNIT, main.clone(), AssetId::DOT).unwrap(); // Balance: DOT = (99,1) where (free,reserved)
     new_order.price = Some(99 * UNIT);
-    assert!(gateway.place_order(main.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(main.clone(), None, new_order.clone())
+        .is_ok());
     check_balance(0u128, 100 * UNIT, main.clone(), AssetId::DOT).unwrap(); // Balance: DOT = (0,100) where (free,reserved)
     check_balance(100 * UNIT, 0u128, main.clone(), AssetId::POLKADEX).unwrap();
 }
@@ -209,13 +224,19 @@ pub fn test_place_market_sell_order() {
 
     setup(main.clone());
     check_balance(100 * UNIT, 0u128, main.clone(), AssetId::POLKADEX).unwrap(); // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(main.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(main.clone(), None, new_order.clone())
+        .is_ok());
     check_balance(99 * UNIT, UNIT, main.clone(), AssetId::POLKADEX).unwrap(); // Balance: DOT = (99,1) where (free,reserved)
     new_order.quantity = 100 * UNIT;
-    assert!(gateway.place_order(main.clone(), None, new_order.clone()).is_err());
+    assert!(gateway
+        .place_order(main.clone(), None, new_order.clone())
+        .is_err());
     check_balance(99 * UNIT, UNIT, main.clone(), AssetId::POLKADEX).unwrap(); // Balance: DOT = (99,1) where (free,reserved)
     new_order.quantity = UNIT;
-    assert!(gateway.place_order(main.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(main.clone(), None, new_order.clone())
+        .is_ok());
     check_balance(98 * UNIT, 2 * UNIT, main.clone(), AssetId::POLKADEX).unwrap(); // Balance: DOT = (0,100) where (free,reserved)
     check_balance(100 * UNIT, 0u128, main.clone(), AssetId::DOT).unwrap();
 }
@@ -267,7 +288,9 @@ pub fn setup_place_buy_and_sell_order_full_ask_limit() {
         check_balance(100 * UNIT, 0u128, buy_order_user.clone(), AssetId::DOT),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved, Ok(())))
-    assert!(gateway.place_order(buy_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(buy_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(98 * UNIT, 2 * UNIT, buy_order_user.clone(), AssetId::DOT),
         Ok(())
@@ -301,7 +324,9 @@ pub fn setup_place_buy_and_sell_order_full_ask_limit() {
         Ok(())
     );
     // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(sell_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(sell_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(99 * UNIT, UNIT, sell_order_user.clone(), AssetId::POLKADEX),
         Ok(())
@@ -326,8 +351,10 @@ pub fn test_settle_trade_full_ask_limit() {
         price: 1 * UNIT,
         amount: 0,
         funds: 0,
+        maker_user_id: buy_order_user.clone(),
         maker_order_id: 1,
         maker_order_uuid: buy_order_uuid,
+        taker_user_id: sell_order_user.clone(),
         taker_order_id: 2,
         taker_order_uuid: sell_order_uuid,
         maker_side: OrderSide::BID,
@@ -375,7 +402,9 @@ pub fn setup_place_buy_and_sell_order_partial_ask_limit() {
         check_balance(100 * UNIT, 0u128, buy_order_user.clone(), AssetId::DOT),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved, Ok(())))
-    assert!(gateway.place_order(buy_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(buy_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(96 * UNIT, 4 * UNIT, buy_order_user.clone(), AssetId::DOT),
         Ok(())
@@ -408,7 +437,9 @@ pub fn setup_place_buy_and_sell_order_partial_ask_limit() {
         ),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(sell_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(sell_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(99 * UNIT, UNIT, sell_order_user.clone(), AssetId::POLKADEX),
         Ok(())
@@ -432,8 +463,10 @@ pub fn test_settle_trade_partial_ask_limit() {
         price: UNIT,
         amount: 0,
         funds: 0,
+        maker_user_id: buy_order_user.clone(),
         maker_order_id: 1,
         maker_order_uuid: buy_order_uuid.clone(),
+        taker_user_id: sell_order_user.clone(),
         taker_order_id: 2,
         taker_order_uuid: sell_order_uuid,
         maker_side: OrderSide::BID,
@@ -502,7 +535,9 @@ pub fn setup_place_buy_and_sell_order_partial_two_ask_limit() {
         check_balance(100 * UNIT, 0u128, buy_order_user.clone(), AssetId::DOT),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved, Ok(())))
-    assert!(gateway.place_order(buy_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(buy_order_user.clone(), None, new_order.clone())
+        .is_ok());
     error!("temp2");
     assert_eq!(
         check_balance(98 * UNIT, 2 * UNIT, buy_order_user.clone(), AssetId::DOT),
@@ -537,7 +572,9 @@ pub fn setup_place_buy_and_sell_order_partial_two_ask_limit() {
         ),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(sell_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(sell_order_user.clone(), None, new_order.clone())
+        .is_ok());
     error!("temp4");
     assert_eq!(
         check_balance(
@@ -567,8 +604,10 @@ pub fn test_settle_trade_partial_two_ask_limit() {
         price: 1 * UNIT,
         amount: 0,
         funds: 0,
+        maker_user_id: buy_order_user.clone(),
         maker_order_id: 1,
         maker_order_uuid: buy_order_uuid.clone(),
+        taker_user_id: sell_order_user.clone(),
         taker_order_id: 2,
         taker_order_uuid: sell_order_uuid.clone(),
         maker_side: OrderSide::BID,
@@ -643,7 +682,9 @@ pub fn setup_place_buy_and_sell_order_full_buy_limit() {
         check_balance(100 * UNIT, 0u128, buy_order_user.clone(), AssetId::DOT),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved, Ok(())))
-    assert!(gateway.place_order(buy_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(buy_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(98 * UNIT, 2 * UNIT, buy_order_user.clone(), AssetId::DOT),
         Ok(())
@@ -676,7 +717,9 @@ pub fn setup_place_buy_and_sell_order_full_buy_limit() {
         ),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(sell_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(sell_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(99 * UNIT, UNIT, sell_order_user.clone(), AssetId::POLKADEX),
         Ok(())
@@ -701,8 +744,10 @@ pub fn test_settle_trade_full_buy_limit() {
         price: UNIT,
         amount: 0,
         funds: 0,
+        maker_user_id: sell_order_user.clone(),
         maker_order_id: 1,
         maker_order_uuid: sell_order_uuid,
+        taker_user_id: buy_order_user.clone(),
         taker_order_id: 2,
         taker_order_uuid: buy_order_uuid,
         maker_side: OrderSide::ASK,
@@ -750,7 +795,9 @@ pub fn setup_place_buy_and_sell_order_partial_buy_limit() {
         check_balance(100 * UNIT, 0u128, buy_order_user.clone(), AssetId::DOT),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved, Ok(())))
-    assert!(gateway.place_order(buy_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(buy_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(96 * UNIT, 4 * UNIT, buy_order_user.clone(), AssetId::DOT),
         Ok(())
@@ -784,7 +831,9 @@ pub fn setup_place_buy_and_sell_order_partial_buy_limit() {
         Ok(())
     );
     // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(sell_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(sell_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(99 * UNIT, UNIT, sell_order_user.clone(), AssetId::POLKADEX),
         Ok(())
@@ -809,8 +858,10 @@ pub fn test_settle_trade_partial_buy_limit() {
         price: UNIT,
         amount: 0,
         funds: 0,
+        maker_user_id: sell_order_user.clone(),
         maker_order_id: 1,
         maker_order_uuid: sell_order_uuid.clone(),
+        taker_user_id: buy_order_user.clone(),
         taker_order_id: 2,
         taker_order_uuid: buy_order_uuid.clone(),
         maker_side: OrderSide::ASK,
@@ -879,7 +930,9 @@ pub fn setup_place_buy_and_sell_order_partial_two_buy_limit() {
         check_balance(100 * UNIT, 0u128, buy_order_user.clone(), AssetId::DOT),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved, Ok(())))
-    assert!(gateway.place_order(buy_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(buy_order_user.clone(), None, new_order.clone())
+        .is_ok());
     error!("temp2");
     assert_eq!(
         check_balance(98 * UNIT, 2 * UNIT, buy_order_user.clone(), AssetId::DOT),
@@ -914,7 +967,9 @@ pub fn setup_place_buy_and_sell_order_partial_two_buy_limit() {
         ),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(sell_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(sell_order_user.clone(), None, new_order.clone())
+        .is_ok());
     error!("temp4");
     assert_eq!(
         check_balance(
@@ -945,8 +1000,10 @@ pub fn test_settle_trade_partial_two_buy_limit() {
         price: UNIT,
         amount: 0,
         funds: 0,
+        maker_user_id: sell_order_user.clone(),
         maker_order_id: 1,
         maker_order_uuid: sell_order_uuid.clone(),
+        taker_user_id: buy_order_user.clone(),
         taker_order_id: 2,
         taker_order_uuid: buy_order_uuid.clone(),
         maker_side: OrderSide::ASK,
@@ -1021,7 +1078,9 @@ pub fn setup_place_buy_and_sell_order_full_ask_market() {
         check_balance(100 * UNIT, 0u128, buy_order_user.clone(), AssetId::DOT),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved, Ok(())))
-    assert!(gateway.place_order(buy_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(buy_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(98 * UNIT, 2 * UNIT, buy_order_user.clone(), AssetId::DOT),
         Ok(())
@@ -1046,7 +1105,9 @@ pub fn setup_place_buy_and_sell_order_full_ask_market() {
 
     setup(main.clone());
     check_balance(100 * UNIT, 0u128, main.clone(), AssetId::POLKADEX).unwrap(); // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(main.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(main.clone(), None, new_order.clone())
+        .is_ok());
     check_balance(99 * UNIT, UNIT, main.clone(), AssetId::POLKADEX).unwrap(); // Balance: DOT = (99,1) where (free,reserved)
     let sell_order_uuid: OrderUUID = (200..202).collect();
     assert!(lock_storage_and_add_order(new_order, sell_order_uuid).is_ok());
@@ -1068,8 +1129,10 @@ pub fn test_settle_trade_full_ask_market() {
         price: 2 * UNIT,
         amount: 0,
         funds: 0,
+        maker_user_id: buy_order_user.clone(),
         maker_order_id: 4,
         maker_order_uuid: buy_order_uuid,
+        taker_user_id: sell_order_user.clone(),
         taker_order_id: 5,
         taker_order_uuid: sell_order_uuid,
         maker_side: OrderSide::BID,
@@ -1117,7 +1180,9 @@ pub fn setup_place_buy_and_sell_order_partial_ask_market() {
         check_balance(100 * UNIT, 0u128, buy_order_user.clone(), AssetId::DOT),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved, Ok(())))
-    assert!(gateway.place_order(buy_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(buy_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(96 * UNIT, 4 * UNIT, buy_order_user.clone(), AssetId::DOT),
         Ok(())
@@ -1142,7 +1207,9 @@ pub fn setup_place_buy_and_sell_order_partial_ask_market() {
 
     setup(main.clone());
     check_balance(100 * UNIT, 0u128, main.clone(), AssetId::POLKADEX).unwrap(); // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(main.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(main.clone(), None, new_order.clone())
+        .is_ok());
     check_balance(99 * UNIT, UNIT, main.clone(), AssetId::POLKADEX).unwrap(); // Balance: DOT = (99,1) where (free,reserved)
     let sell_order_uuid: OrderUUID = (200..202).collect();
     assert!(lock_storage_and_add_order(new_order, sell_order_uuid).is_ok());
@@ -1164,8 +1231,10 @@ pub fn test_settle_trade_partial_ask_market() {
         price: 2 * UNIT,
         amount: 0,
         funds: 0,
+        maker_user_id: buy_order_user.clone(),
         maker_order_id: 1,
         maker_order_uuid: buy_order_uuid.clone(),
+        taker_user_id: sell_order_user.clone(),
         taker_order_id: 2,
         taker_order_uuid: sell_order_uuid,
         maker_side: OrderSide::BID,
@@ -1233,7 +1302,9 @@ pub fn setup_place_buy_and_sell_order_partial_two_ask_market() {
         check_balance(100 * UNIT, 0u128, buy_order_user.clone(), AssetId::DOT),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved, Ok(())))
-    assert!(gateway.place_order(buy_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(buy_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(98 * UNIT, 2 * UNIT, buy_order_user.clone(), AssetId::DOT),
         Ok(())
@@ -1258,7 +1329,9 @@ pub fn setup_place_buy_and_sell_order_partial_two_ask_market() {
 
     setup(main.clone());
     check_balance(100 * UNIT, 0u128, main.clone(), AssetId::POLKADEX).unwrap(); // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(main.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(main.clone(), None, new_order.clone())
+        .is_ok());
     check_balance(98 * UNIT, 2 * UNIT, main.clone(), AssetId::POLKADEX).unwrap(); // Balance: DOT = (99,1) where (free,reserved)
     let sell_order_uuid: OrderUUID = (200..202).collect();
     assert!(lock_storage_and_add_order(new_order, sell_order_uuid).is_ok());
@@ -1280,8 +1353,10 @@ pub fn test_settle_trade_partial_two_ask_market() {
         price: 2 * UNIT,
         amount: 0,
         funds: 0,
+        maker_user_id: buy_order_user.clone(),
         maker_order_id: 2354,
         maker_order_uuid: buy_order_uuid.clone(),
+        taker_user_id: sell_order_user.clone(),
         taker_order_id: 324652,
         taker_order_uuid: sell_order_uuid.clone(),
         maker_side: OrderSide::BID,
@@ -1356,7 +1431,9 @@ pub fn setup_place_buy_and_sell_order_full_buy_market() {
         check_balance(100 * UNIT, 0u128, buy_order_user.clone(), AssetId::DOT),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved, Ok(())))
-    assert!(gateway.place_order(buy_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(buy_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(98 * UNIT, 2 * UNIT, buy_order_user.clone(), AssetId::DOT),
         Ok(())
@@ -1389,7 +1466,9 @@ pub fn setup_place_buy_and_sell_order_full_buy_market() {
         ),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(sell_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(sell_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(
             98 * UNIT,
@@ -1419,8 +1498,10 @@ pub fn test_settle_trade_full_buy_market() {
         price: UNIT,
         amount: 0,
         funds: 0,
+        maker_user_id: sell_order_user.clone(),
         maker_order_id: 1,
         maker_order_uuid: sell_order_uuid,
+        taker_user_id: buy_order_user.clone(),
         taker_order_id: 2,
         taker_order_uuid: buy_order_uuid,
         maker_side: OrderSide::ASK,
@@ -1468,7 +1549,9 @@ pub fn setup_place_buy_and_sell_order_partial_bid_market() {
         check_balance(100 * UNIT, 0u128, buy_order_user.clone(), AssetId::DOT),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved, Ok(())))
-    assert!(gateway.place_order(buy_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(buy_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(98 * UNIT, 2 * UNIT, buy_order_user.clone(), AssetId::DOT),
         Ok(())
@@ -1502,7 +1585,9 @@ pub fn setup_place_buy_and_sell_order_partial_bid_market() {
         Ok(())
     );
     // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(sell_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(sell_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(99 * UNIT, UNIT, sell_order_user.clone(), AssetId::POLKADEX),
         Ok(())
@@ -1527,8 +1612,10 @@ pub fn test_settle_trade_partial_bid_market() {
         price: UNIT,
         amount: 0,
         funds: 0,
+        maker_user_id: sell_order_user.clone(),
         maker_order_id: 1,
         maker_order_uuid: sell_order_uuid.clone(),
+        taker_user_id: buy_order_user.clone(),
         taker_order_id: 2,
         taker_order_uuid: buy_order_uuid.clone(),
         maker_side: OrderSide::ASK,
@@ -1596,7 +1683,9 @@ pub fn setup_place_buy_and_sell_order_partial_two_bid_market() {
         check_balance(100 * UNIT, 0u128, buy_order_user.clone(), AssetId::DOT),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved, Ok(())))
-    assert!(gateway.place_order(buy_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(buy_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(98 * UNIT, 2 * UNIT, buy_order_user.clone(), AssetId::DOT),
         Ok(())
@@ -1630,7 +1719,9 @@ pub fn setup_place_buy_and_sell_order_partial_two_bid_market() {
         Ok(())
     );
     // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(sell_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(sell_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(
             97 * UNIT,
@@ -1660,8 +1751,10 @@ pub fn test_settle_trade_partial_two_bid_market() {
         price: UNIT,
         amount: 0,
         funds: 0,
+        maker_user_id: sell_order_user.clone(),
         maker_order_id: 1,
         maker_order_uuid: sell_order_uuid.clone(),
+        taker_user_id: buy_order_user.clone(),
         taker_order_id: 2,
         taker_order_uuid: buy_order_uuid.clone(),
         maker_side: OrderSide::ASK,
@@ -1727,7 +1820,9 @@ pub fn setup_test_cancel_limit_bid_order() {
         check_balance(100 * UNIT, 0u128, buy_order_user.clone(), AssetId::DOT),
         Ok(())
     ); // Balance:  DOT = (100,0) where (free,reserved, Ok(())))
-    assert!(gateway.place_order(buy_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(buy_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(98 * UNIT, 2 * UNIT, buy_order_user.clone(), AssetId::DOT),
         Ok(())
@@ -1749,7 +1844,10 @@ pub fn test_cancel_limit_bid_order() {
         },
         order_id: buy_order_uuid.clone(),
     };
-    assert_eq!(gateway.cancel_order(buy_order_user.clone(), None, order), Ok(()));
+    assert_eq!(
+        gateway.cancel_order(buy_order_user.clone(), None, order),
+        Ok(())
+    );
     assert!(process_cancel_order(buy_order_uuid).is_ok());
     assert_eq!(
         check_balance(100 * UNIT, 0u128, buy_order_user.clone(), AssetId::DOT),
@@ -1784,7 +1882,9 @@ pub fn setup_test_cancel_ask_order() {
         Ok(())
     );
     // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(sell_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(sell_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(99 * UNIT, UNIT, sell_order_user.clone(), AssetId::POLKADEX),
         Ok(())
@@ -1806,7 +1906,10 @@ pub fn test_cancel_ask_order() {
         },
         order_id: sell_order_uuid.clone(),
     };
-    assert_eq!(gateway.cancel_order(sell_order_user.clone(), None, order), Ok(()));
+    assert_eq!(
+        gateway.cancel_order(sell_order_user.clone(), None, order),
+        Ok(())
+    );
     assert!(process_cancel_order(sell_order_uuid).is_ok());
     assert_eq!(
         check_balance(
@@ -1846,15 +1949,17 @@ pub fn setup_process_create_order() {
         Ok(())
     );
     // Balance:  DOT = (100,0) where (free,reserved)
-    assert!(gateway.place_order(sell_order_user.clone(), None, new_order.clone()).is_ok());
+    assert!(gateway
+        .place_order(sell_order_user.clone(), None, new_order.clone())
+        .is_ok());
     assert_eq!(
         check_balance(99 * UNIT, UNIT, sell_order_user.clone(), AssetId::POLKADEX),
         Ok(())
     );
     let request_id = insert_order_into_cache(new_order).unwrap();
     assert_eq!(
-         load_storage_check_id_in_insert_order_cache(request_id),
-         Ok(true)
+        load_storage_check_id_in_insert_order_cache(request_id),
+        Ok(true)
     );
 }
 
@@ -1865,7 +1970,7 @@ pub fn test_process_create_order() {
     assert_eq!(process_create_order(request_id, order_uuid.clone()), Ok(()));
     assert_eq!(
         load_storage_check_id_in_insert_order_cache(request_id),
-         Ok(false)
+        Ok(false)
     );
     assert_eq!(
         lock_storage_and_check_order_in_orderbook(order_uuid),
@@ -1887,7 +1992,9 @@ fn insert_order_into_cache(order: Order) -> Result<RequestId, GatewayError> {
     Ok(current_request_id)
 }
 
-fn load_storage_check_id_in_insert_order_cache(request_id: RequestId) -> Result<bool, GatewayError> {
+fn load_storage_check_id_in_insert_order_cache(
+    request_id: RequestId,
+) -> Result<bool, GatewayError> {
     let mutex = CreateOrderCache::load().map_err(|_| GatewayError::NullPointer)?;
     let mut create_cache = match mutex.lock() {
         Ok(guard) => guard,
@@ -1895,10 +2002,9 @@ fn load_storage_check_id_in_insert_order_cache(request_id: RequestId) -> Result<
             error!("Could not acquire lock on cancel cache pointer: {}", e);
             return Err(GatewayError::UnableToLock);
         }
-
     };
     if let Some(_order) = create_cache.remove_order(&request_id) {
-        return Ok(true)
+        return Ok(true);
     }
     Ok(false)
 }

--- a/enclave/src/tests.rs
+++ b/enclave/src/tests.rs
@@ -26,6 +26,7 @@ use crate::test_orderbook_storage;
 use crate::test_polkadex_gateway;
 use crate::test_proxy;
 use crate::top_pool;
+use crate::ss58check;
 
 use crate::{Timeout, WorkerRequest, WorkerResponse};
 use log::*;
@@ -188,6 +189,9 @@ pub extern "C" fn test_main_entrance() -> size_t {
         trusted_operation_verifier::tests::given_nonsense_text_in_request_then_decode_fails,
         trusted_operation_verifier::tests::given_valid_operation_with_invalid_signature_then_return_error,
         io_handler_extensions::tests::test_given_io_handler_methods_then_retrieve_all_names_as_string,
+
+        // Utility
+        ss58check::tests::convert_account_id_to_and_from_ss58check,
 
         // Substratee Tests
         top_pool::base_pool::test_should_import_transaction_to_ready,

--- a/polkadex-primitives/src/types.rs
+++ b/polkadex-primitives/src/types.rs
@@ -198,6 +198,8 @@ pub struct Response {
 // Order Update Events
 #[derive(Debug, Clone, Encode, Decode, PartialEq)]
 pub struct OrderUpdate {
+    // User ID
+    pub user_id: AccountId,
     // Market unique identifier
     pub market_id: MarketId,
     // Unique order ID
@@ -239,10 +241,14 @@ pub struct TradeEvent {
     pub amount: PriceAndQuantityType,
     // Trade Funds (amount*price)
     pub funds: PriceAndQuantityType,
+    // Maker's account ID
+    pub maker_user_id: AccountId,
     // Maker's trade Order Id
     pub maker_order_id: OrderId,
     // Maker's trade Order UUID
     pub maker_order_uuid: OrderUUID,
+    // Taker's account ID
+    pub taker_user_id: AccountId,
     // Taker's trade Order Id
     pub taker_order_id: OrderId,
     // Taker's trade Order UUID


### PR DESCRIPTION
Add the user IDs returned from OpenFinex to the `OrderUpdate` and `TradeEvent` objects. This required to add conversion logic from ss58check -> AccountId. This is already available in Substrate, but not in `no_std`, so I had to (again) copy code from Substrate into our enclave.

Closes #101 