### PR TITLE
Fix for Deadlock

### DIFF
--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -30,7 +30,7 @@
 #[macro_use]
 extern crate sgx_tstd as std;
 
-use crate::channel_storage::{load_channel_storage, ChannelType};
+use crate::channel_storage::{create_channel_get_receiver, ChannelType};
 use crate::constants::{
     CALL_WORKER, OCEX_DEPOSIT, OCEX_MODULE, OCEX_RELEASE, OCEX_WITHDRAW, SHIELD_FUNDS,
 };
@@ -447,13 +447,11 @@ extern "C" {
 
 #[no_mangle]
 pub unsafe extern "C" fn run_db_thread() -> sgx_status_t {
-    let receiver = &if let Ok(channel) = load_channel_storage() {
-        channel
+    let receiver = if let Ok(receiver) = create_channel_get_receiver() {
+        receiver
     } else {
-        error!("Failed to load channel");
         return sgx_status_t::SGX_ERROR_UNEXPECTED;
-    }
-    .receiver;
+    };
 
     loop {
         match receiver.recv() {

--- a/worker/src/tests/mod.rs
+++ b/worker/src/tests/mod.rs
@@ -31,6 +31,10 @@ pub fn run_enclave_tests(matches: &ArgMatches, port: &str) {
     let enclave = enclave_init().unwrap();
     let eid = enclave.geteid();
 
+    // ------------------------------------------------------------------------
+    // Start DB Handler Thread
+    crate::db_handler::DBHandler::initialize(eid);
+
     if matches.is_present("all") || matches.is_present("unit") {
         println!("Running unit Tests");
         enclave_test(eid).unwrap();


### PR DESCRIPTION
Fixed deadlock in integration testing, which was found to be caused by the receiver being stored and then retrieved, closes #236 