### PR TITLE
Clean up and fix account and nonce registry error

### DIFF
--- a/client/polkadex_commands.py
+++ b/client/polkadex_commands.py
@@ -159,7 +159,7 @@ def direct_cancel_order(acc, proxy, base, quote, orderid):
         accs = acc_arg(acc) + proxy_arg(proxy)
     else:
         accs = acc_arg(acc)
-    market_args = base_arg(base) + quote_arg(quote) + markettype
+    market_args = base_arg(base) + quote_arg(quote)
     order_args = orderid_arg(orderid)
 
     ret = subprocess.run(cli + ["trusted", "cancel_order"] + accs + market_args + order_args + direct_tail(), stdout=subprocess.PIPE)

--- a/enclave/src/accounts_nonce_storage/error.rs
+++ b/enclave/src/accounts_nonce_storage/error.rs
@@ -1,0 +1,42 @@
+// This file is part of Polkadex.
+
+// Copyright (C) 2020-2021 Polkadex oü and Supercomputing Systems AG
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use derive_more::{Display, From};
+use std::result::Result as StdResult;
+
+pub type Result<T> = StdResult<T, Error>;
+
+#[derive(Debug, Display, From, PartialEq, Eq)]
+pub enum Error {
+    /// Could not load the registry for some reason
+    CouldNotLoadRegistry,
+    /// Could not get mutex
+    CouldNotGetMutex,
+    /// Main account is already registered
+    AccountAlreadyRegistered,
+    /// Main account is not registered
+    AccountNotRegistered,
+    /// The proxy is already registered
+    ProxyAlreadyRegistered,
+    /// The proxy is not registered
+    ProxyNotRegistered,
+    /// Nonce is not initialized
+    NonceUninitialized,
+    /// Nonce validation failed (didn't match)
+    NonceValidationFailed,
+}

--- a/enclave/src/accounts_nonce_storage/mod.rs
+++ b/enclave/src/accounts_nonce_storage/mod.rs
@@ -16,8 +16,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+pub mod accounts_storage;
+pub mod error;
+pub mod nonce_storage;
+pub mod test_proxy;
+
 use chain_relay::{storage_proof::StorageProofChecker, Header};
 use codec::Encode;
+use error::{Error, Result};
 use frame_support::{metadata::StorageHasher, PalletId};
 use log::*;
 use polkadex_sgx_primitives::NonceData;
@@ -30,16 +36,8 @@ use std::sync::{
     Arc, SgxMutex, SgxMutexGuard,
 };
 
-use crate::{
-    // accounts_storage::{AccountsStorageError, PolkadexAccountsStorage},
-    // nonce_storage::{NonceStorageError, PolkadexNonceStorage},
-    polkadex_gateway::GatewayError,
-    utils::UnwrapOrSgxErrorUnexpected,
-};
+use crate::utils::UnwrapOrSgxErrorUnexpected;
 
-pub mod accounts_storage;
-pub mod nonce_storage;
-pub mod test_proxy;
 pub use accounts_storage::*;
 pub use nonce_storage::*;
 
@@ -124,14 +122,11 @@ fn key_hash<K: Encode>(key: &K, hasher: &StorageHasher) -> Vec<u8> {
     }
 }
 
-pub fn create_in_memory_accounts_and_nonce_storage(
-    accounts: Vec<PolkadexAccount>,
-) -> Result<(), GatewayError> {
+pub fn create_in_memory_accounts_and_nonce_storage(accounts: Vec<PolkadexAccount>) {
     let storage = AccountsNonceStorage::create(accounts);
     let storage_ptr = Arc::new(SgxMutex::<AccountsNonceStorage>::new(storage));
     let ptr = Arc::into_raw(storage_ptr);
     GLOBAL_ACCOUNTS_AND_NONCE_STORAGE.store(ptr as *mut (), Ordering::SeqCst);
-    Ok(())
 }
 
 #[derive(Debug, PartialEq)]
@@ -148,33 +143,25 @@ impl AccountsNonceStorage {
         }
     }
 
-    fn register_main_account(&mut self, acc: AccountId) -> Result<(), AccountRegistryError> {
+    fn register_main_account(&mut self, acc: AccountId) -> Result<()> {
         self.accounts_storage.add_main_account(acc.clone())?;
         self.nonce_storage.initialize_nonce(acc);
         Ok(())
     }
 
-    fn register_proxy_account(
-        &mut self,
-        acc: AccountId,
-        proxy: AccountId,
-    ) -> Result<(), AccountRegistryError> {
+    fn register_proxy_account(&mut self, acc: AccountId, proxy: AccountId) -> Result<()> {
         self.accounts_storage.add_proxy(acc, proxy.clone())?;
         self.nonce_storage.initialize_nonce(proxy);
         Ok(())
     }
 
-    fn remove_main_account(&mut self, acc: AccountId) -> Result<(), AccountRegistryError> {
+    fn remove_main_account(&mut self, acc: AccountId) -> Result<()> {
         self.accounts_storage.remove_main_account(acc.clone())?;
         self.nonce_storage.remove_nonce(acc);
         Ok(())
     }
 
-    fn remove_proxy_account(
-        &mut self,
-        acc: AccountId,
-        proxy: AccountId,
-    ) -> Result<(), AccountRegistryError> {
+    fn remove_proxy_account(&mut self, acc: AccountId, proxy: AccountId) -> Result<()> {
         self.accounts_storage.remove_proxy(acc, proxy.clone())?;
         self.nonce_storage.remove_nonce(proxy);
         Ok(())
@@ -184,108 +171,89 @@ impl AccountsNonceStorage {
         self.accounts_storage.accounts.contains_key(&acc.encode())
     }
 
-    fn check_if_proxy_registered(
-        &self,
-        acc: AccountId,
-        proxy: AccountId,
-    ) -> Result<bool, AccountRegistryError> {
+    fn check_if_proxy_registered(&self, acc: AccountId, proxy: AccountId) -> Result<bool> {
         if let Some(list_of_proxies) = self.accounts_storage.accounts.get(&acc.encode()) {
             Ok(list_of_proxies.contains(&proxy))
         } else {
-            Err(AccountRegistryError::MainAccountNoRegistedForGivenProxy)
+            Err(Error::AccountNotRegistered)
         }
     }
 
     // Nonce related functions
 
-    fn get_nonce(&self, acc: AccountId) -> Result<u32, AccountRegistryError> {
-        self.nonce_storage
-            .read_nonce(acc)
-            .map_err(AccountRegistryError::NonceStorageError)
+    fn get_nonce(&self, acc: AccountId) -> Result<u32> {
+        self.nonce_storage.read_nonce(acc)
     }
 
-    fn validate_and_increment_nonce(
-        &mut self,
-        acc: AccountId,
-        nonce: u32,
-    ) -> Result<(), AccountRegistryError> {
+    fn validate_and_increment_nonce(&mut self, acc: AccountId, nonce: u32) -> Result<()> {
         if self.nonce_storage.read_nonce(acc.clone())? != nonce {
-            return Err(AccountRegistryError::NonceValidationFailed);
+            return Err(Error::NonceValidationFailed);
         }
         self.nonce_storage.increment_nonce(acc)?;
         Ok(())
     }
 }
 
-pub fn check_if_main_account_registered(acc: AccountId) -> Result<bool, AccountRegistryError> {
+pub fn check_if_main_account_registered(acc: AccountId) -> Result<bool> {
     // Acquire lock on proxy_registry
     let mutex = load_registry()?;
-    let storage: SgxMutexGuard<AccountsNonceStorage> = mutex
-        .lock()
-        .map_err(|_| AccountRegistryError::CouldNotGetMutex)?;
+    let storage: SgxMutexGuard<AccountsNonceStorage> =
+        mutex.lock().map_err(|_| Error::CouldNotGetMutex)?;
     let result = storage.check_if_main_account_registered(acc);
     Ok(result)
 }
 
-pub fn check_if_proxy_registered(
-    acc: AccountId,
-    proxy: AccountId,
-) -> Result<bool, AccountRegistryError> {
+pub fn check_if_proxy_registered(acc: AccountId, proxy: AccountId) -> Result<bool> {
     // Acquire lock on proxy_registry
     let mutex = load_registry()?;
-    let storage: SgxMutexGuard<AccountsNonceStorage> = mutex
-        .lock()
-        .map_err(|_| AccountRegistryError::CouldNotGetMutex)?;
+    let storage: SgxMutexGuard<AccountsNonceStorage> =
+        mutex.lock().map_err(|_| Error::CouldNotGetMutex)?;
 
     storage.check_if_proxy_registered(acc, proxy)
 }
 
-pub fn add_main_account(main_acc: AccountId) -> Result<(), AccountRegistryError> {
+pub fn add_main_account(main_acc: AccountId) -> Result<()> {
     // Aquire lock on proxy_registry
     let mutex = load_registry()?;
-    let mut storage: SgxMutexGuard<AccountsNonceStorage> = mutex
-        .lock()
-        .map_err(|_| AccountRegistryError::CouldNotGetMutex)?;
+    let mut storage: SgxMutexGuard<AccountsNonceStorage> =
+        mutex.lock().map_err(|_| Error::CouldNotGetMutex)?;
     storage.register_main_account(main_acc)?;
     Ok(())
 }
 
-pub fn remove_main_account(main_acc: AccountId) -> Result<(), AccountRegistryError> {
+pub fn remove_main_account(main_acc: AccountId) -> Result<()> {
     // Aquire lock on proxy_registry
     let mutex = load_registry()?;
-    let mut storage: SgxMutexGuard<AccountsNonceStorage> = mutex
-        .lock()
-        .map_err(|_| AccountRegistryError::CouldNotGetMutex)?;
+    let mut storage: SgxMutexGuard<AccountsNonceStorage> =
+        mutex.lock().map_err(|_| Error::CouldNotGetMutex)?;
     storage.remove_main_account(main_acc)?;
     Ok(())
 }
 
-pub fn add_proxy(main_acc: AccountId, proxy: AccountId) -> Result<(), AccountRegistryError> {
+pub fn add_proxy(main_acc: AccountId, proxy: AccountId) -> Result<()> {
     // Aquire lock on proxy_registry
     let mutex = load_registry()?;
-    let mut storage: SgxMutexGuard<AccountsNonceStorage> = mutex
-        .lock()
-        .map_err(|_| AccountRegistryError::CouldNotGetMutex)?;
+    let mut storage: SgxMutexGuard<AccountsNonceStorage> =
+        mutex.lock().map_err(|_| Error::CouldNotGetMutex)?;
     storage.register_proxy_account(main_acc, proxy)?;
     Ok(())
 }
 
-pub fn remove_proxy(main_acc: AccountId, proxy: AccountId) -> Result<(), AccountRegistryError> {
+pub fn remove_proxy(main_acc: AccountId, proxy: AccountId) -> Result<()> {
     // Aquire lock on proxy_registry
     let mutex = load_registry()?;
-    let mut storage: SgxMutexGuard<AccountsNonceStorage> = mutex
-        .lock()
-        .map_err(|_| AccountRegistryError::CouldNotGetMutex)?;
+    let mut storage: SgxMutexGuard<AccountsNonceStorage> =
+        mutex.lock().map_err(|_| Error::CouldNotGetMutex)?;
     storage.remove_proxy_account(main_acc, proxy)?;
     Ok(())
 }
 
-pub fn load_registry() -> Result<&'static SgxMutex<AccountsNonceStorage>, AccountRegistryError> {
+pub fn load_registry() -> Result<&'static SgxMutex<AccountsNonceStorage>> {
     let ptr = GLOBAL_ACCOUNTS_AND_NONCE_STORAGE.load(Ordering::SeqCst)
         as *mut SgxMutex<AccountsNonceStorage>;
     if ptr.is_null() {
         error!("Null pointer to polkadex account registry");
-        Err(AccountRegistryError::CouldNotLoadRegistry)
+        Err(Error::CouldNotLoadRegistry)
     } else {
         Ok(unsafe { &*ptr })
     }
@@ -293,23 +261,19 @@ pub fn load_registry() -> Result<&'static SgxMutex<AccountsNonceStorage>, Accoun
 
 //Nonce related functions
 
-pub fn get_nonce(main_acc: AccountId) -> Result<u32, AccountRegistryError> {
+pub fn get_nonce(main_acc: AccountId) -> Result<u32> {
     // Aquire lock on proxy_registry
     let mutex = load_registry()?;
-    let storage: SgxMutexGuard<AccountsNonceStorage> = mutex
-        .lock()
-        .map_err(|_| AccountRegistryError::CouldNotGetMutex)?;
+    let storage: SgxMutexGuard<AccountsNonceStorage> =
+        mutex.lock().map_err(|_| Error::CouldNotGetMutex)?;
     storage.get_nonce(main_acc)
 }
 
-pub fn lock_nonce_storage_extend_from_disk(
-    data: Vec<NonceData>,
-) -> Result<(), AccountRegistryError> {
+pub fn lock_nonce_storage_extend_from_disk(data: Vec<NonceData>) -> Result<()> {
     // Aquire lock on proxy_registry
     let mutex = load_registry()?;
-    let mut storage: SgxMutexGuard<AccountsNonceStorage> = mutex
-        .lock()
-        .map_err(|_| AccountRegistryError::CouldNotGetMutex)?;
+    let mut storage: SgxMutexGuard<AccountsNonceStorage> =
+        mutex.lock().map_err(|_| Error::CouldNotGetMutex)?;
     storage.nonce_storage.extend_from_disk_data(data);
     Ok(())
 }
@@ -318,59 +282,28 @@ pub fn auth_user_validate_increment_nonce(
     acc: AccountId,
     proxy_acc: Option<AccountId>,
     nonce: u32,
-) -> Result<(), AccountRegistryError> {
+) -> Result<()> {
     let mutex = load_registry()?;
-    let mut storage: SgxMutexGuard<AccountsNonceStorage> = mutex
-        .lock()
-        .map_err(|_| AccountRegistryError::CouldNotGetMutex)?;
+    let mut storage: SgxMutexGuard<AccountsNonceStorage> =
+        mutex.lock().map_err(|_| Error::CouldNotGetMutex)?;
 
     match proxy_acc {
         Some(proxy) => {
             if !storage.check_if_proxy_registered(acc.clone(), proxy)? {
-                return Err(AccountRegistryError::ProxyAccountNoRegistedForGivenMainAccount);
+                return Err(Error::ProxyNotRegistered);
             }
         }
         None => {
             if !storage.check_if_main_account_registered(acc.clone()) {
-                return Err(AccountRegistryError::MainAccountNoRegistedForGivenProxy);
+                return Err(Error::AccountNotRegistered);
             }
         }
     }
     if storage.nonce_storage.read_nonce(acc.clone())? != nonce {
-        return Err(AccountRegistryError::NonceValidationFailed);
+        return Err(Error::NonceValidationFailed);
     }
     storage.nonce_storage.increment_nonce(acc)?;
     Ok(())
-}
-
-#[derive(Eq, Debug, PartialEq, PartialOrd)]
-pub enum AccountRegistryError {
-    /// Could not load the registry for some reason
-    CouldNotLoadRegistry,
-    /// Could not get mutex
-    CouldNotGetMutex,
-    /// No registed main account for given proxy
-    MainAccountNoRegistedForGivenProxy,
-    /// No registed proxy account for given main account
-    ProxyAccountNoRegistedForGivenMainAccount,
-    /// Nonce validation failed (didn't match)
-    NonceValidationFailed,
-    /// PolkadexAccountsStorage Error
-    AccountStorageError(AccountsStorageError),
-    /// PolkadexNonceStorage Error
-    NonceStorageError(NonceStorageError),
-}
-
-impl From<AccountsStorageError> for AccountRegistryError {
-    fn from(error: AccountsStorageError) -> AccountRegistryError {
-        AccountRegistryError::AccountStorageError(error)
-    }
-}
-
-impl From<NonceStorageError> for AccountRegistryError {
-    fn from(error: NonceStorageError) -> AccountRegistryError {
-        AccountRegistryError::NonceStorageError(error)
-    }
 }
 
 pub mod tests {
@@ -380,7 +313,7 @@ pub mod tests {
     use sp_core::{ed25519 as ed25519_core, Pair};
 
     pub fn create_and_load_registry() {
-        assert!(create_in_memory_accounts_and_nonce_storage(vec![]).is_ok());
+        create_in_memory_accounts_and_nonce_storage(vec![]);
         assert_eq!(
             *load_registry().unwrap().lock().unwrap(),
             AccountsNonceStorage::create(vec![])

--- a/enclave/src/accounts_nonce_storage/nonce_storage.rs
+++ b/enclave/src/accounts_nonce_storage/nonce_storage.rs
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use super::error::{Error, Result};
 use codec::Encode;
 use log::*;
 use polkadex_sgx_primitives::NonceData;
@@ -46,17 +47,17 @@ impl PolkadexNonceStorage {
         in_memory_map
     }
 
-    pub fn read_nonce(&self, acc: AccountId) -> Result<u32, NonceStorageError> {
+    pub fn read_nonce(&self, acc: AccountId) -> Result<u32> {
         debug!("reading nonce from acc: {:?}", acc);
         if let Some(nonce) = self.storage.get(&acc.encode()) {
             Ok(*nonce)
         } else {
             error!("Nonce uninitialized");
-            Err(NonceStorageError::NonceUninitialized)
+            Err(Error::NonceUninitialized)
         }
     }
 
-    pub fn increment_nonce(&mut self, acc: AccountId) -> Result<(), NonceStorageError> {
+    pub fn increment_nonce(&mut self, acc: AccountId) -> Result<()> {
         let nonce = self.read_nonce(acc.clone())?;
         self.storage.insert(acc.encode(), nonce + 1u32);
         Ok(())
@@ -78,12 +79,6 @@ impl PolkadexNonceStorage {
                 .map(|entry| (entry.account_id.encode(), entry.nonce)),
         );
     }
-}
-
-#[derive(Eq, Debug, PartialEq, PartialOrd)]
-pub enum NonceStorageError {
-    /// Nonce is not initialized
-    NonceUninitialized,
 }
 
 pub mod tests {

--- a/enclave/src/accounts_nonce_storage/test_proxy.rs
+++ b/enclave/src/accounts_nonce_storage/test_proxy.rs
@@ -83,7 +83,7 @@ pub fn test_check_if_proxy_registered() {
     .unwrap(),);
     assert_eq!(
         accounts_nonce_storage::check_if_proxy_registered(main_account_false, dummy_account_false),
-        Err(Error::ProxyNotRegistered)
+        Err(Error::AccountNotRegistered)
     );
 }
 

--- a/enclave/src/accounts_nonce_storage/test_proxy.rs
+++ b/enclave/src/accounts_nonce_storage/test_proxy.rs
@@ -16,15 +16,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use super::error::Error;
+use crate::{accounts_nonce_storage, accounts_nonce_storage::AccountsNonceStorage};
 use codec::Encode;
 use polkadex_sgx_primitives::AccountId;
 use sgx_tstd::sync::SgxMutexGuard;
 use substratee_worker_primitives::get_account;
-
-use crate::{
-    accounts_nonce_storage, accounts_nonce_storage::AccountRegistryError,
-    accounts_nonce_storage::AccountsNonceStorage,
-};
 
 pub fn get_dummy_map(storage: &mut SgxMutexGuard<AccountsNonceStorage>) {
     let main_account_one: AccountId = get_account("first_account");
@@ -49,7 +46,7 @@ pub fn get_dummy_map(storage: &mut SgxMutexGuard<AccountsNonceStorage>) {
 }
 
 pub fn initialize_dummy() {
-    accounts_nonce_storage::create_in_memory_accounts_and_nonce_storage(vec![]).unwrap();
+    accounts_nonce_storage::create_in_memory_accounts_and_nonce_storage(vec![]);
     let mutex = accounts_nonce_storage::load_registry().unwrap();
     let mut storage = mutex.lock().unwrap();
     get_dummy_map(&mut storage);
@@ -86,7 +83,7 @@ pub fn test_check_if_proxy_registered() {
     .unwrap(),);
     assert_eq!(
         accounts_nonce_storage::check_if_proxy_registered(main_account_false, dummy_account_false),
-        Err(AccountRegistryError::MainAccountNoRegistedForGivenProxy)
+        Err(Error::ProxyNotRegistered)
     );
 }
 

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -416,11 +416,7 @@ pub unsafe extern "C" fn accept_pdex_accounts(
         return status;
     }
 
-    if accounts_nonce_storage::create_in_memory_accounts_and_nonce_storage(polkadex_accounts)
-        .is_err()
-    {
-        return sgx_status_t::SGX_ERROR_UNEXPECTED;
-    };
+    accounts_nonce_storage::create_in_memory_accounts_and_nonce_storage(polkadex_accounts);
 
     sgx_status_t::SGX_SUCCESS
 }
@@ -435,8 +431,7 @@ fn initialize_and_extend_storages(
             .map_err(|_| sgx_status_t::SGX_ERROR_UNEXPECTED)?;
     }
     if accounts_nonce_storage::load_registry().is_err() {
-        accounts_nonce_storage::create_in_memory_accounts_and_nonce_storage(vec![])
-            .map_err(|_| sgx_status_t::SGX_ERROR_UNEXPECTED)?;
+        accounts_nonce_storage::create_in_memory_accounts_and_nonce_storage(vec![]);
     }
     if polkadex_orderbook_storage::load_orderbook().is_err() {
         polkadex_orderbook_storage::create_in_memory_orderbook_storage(vec![])

--- a/enclave/src/openfinex/openfinex_api.rs
+++ b/enclave/src/openfinex/openfinex_api.rs
@@ -28,7 +28,7 @@ pub enum OpenFinexApiError {
     SerializationError(String),
 
     /// Error communicating via web socket
-    WebSocketError(String),
+    OpenfinexWebSocketError(String),
 
     /// Error when parsing response
     ResponseParsingError(String),

--- a/enclave/src/openfinex/openfinex_api_impl.rs
+++ b/enclave/src/openfinex/openfinex_api_impl.rs
@@ -78,7 +78,7 @@ impl OpenFinexApi for OpenFinexApiImpl {
         self.websocket_client
             .clone()
             .send_request(&request.to_request_string().as_bytes())
-            .map_err(|e| OpenFinexApiError::WebSocketError(format!("{:?}", e)))
+            .map_err(|e| OpenFinexApiError::OpenfinexWebSocketError(format!("{:?}", e)))
     }
 
     fn cancel_order(
@@ -100,7 +100,7 @@ impl OpenFinexApi for OpenFinexApiImpl {
         self.websocket_client
             .clone()
             .send_request(&request.to_request_string().as_bytes())
-            .map_err(|e| OpenFinexApiError::WebSocketError(format!("{:?}", e)))
+            .map_err(|e| OpenFinexApiError::OpenfinexWebSocketError(format!("{:?}", e)))
     }
 
     fn withdraw_funds(&self, _request_id: RequestId) -> OpenFinexApiResult<()> {

--- a/enclave/src/polkadex_gateway.rs
+++ b/enclave/src/polkadex_gateway.rs
@@ -345,12 +345,8 @@ pub fn authenticate_user_and_validate_nonce(
     proxy_acc: Option<AccountId>,
     nonce: u32,
 ) -> Result<(), GatewayError> {
-    if accounts_nonce_storage::auth_user_validate_increment_nonce(main_acc, proxy_acc, nonce)
-        .is_err()
-    {
-        return Err(GatewayError::NonceInvalid);
-    }
-    Ok(())
+    accounts_nonce_storage::auth_user_validate_increment_nonce(main_acc, proxy_acc, nonce)
+        .map_err(GatewayError::AccountRegistryError)
 }
 
 pub fn authenticate_user(

--- a/enclave/src/polkadex_gateway.rs
+++ b/enclave/src/polkadex_gateway.rs
@@ -17,7 +17,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 pub extern crate alloc;
-use alloc::fmt::Result as FormatResult;
+use derive_more::{Display, From};
 use frame_support::ensure;
 use log::*;
 use polkadex_sgx_primitives::types::{
@@ -36,16 +36,7 @@ use crate::polkadex_cache::cancel_order_cache::CancelOrderCache;
 use crate::polkadex_cache::create_order_cache::CreateOrderCache;
 use crate::polkadex_gateway;
 use crate::polkadex_orderbook_storage;
-use accounts_nonce_storage::AccountRegistryError;
-
-impl alloc::fmt::Display for GatewayError {
-    fn fmt(&self, f: &mut alloc::fmt::Formatter) -> FormatResult {
-        write!(f, "{:?}", self)
-        // or, alternatively:
-        // fmt::Debug::fmt(self, f)
-    }
-}
-
+use accounts_nonce_storage::error::Error as AccountRegistryError;
 /// Trait for callbacks coming from the OpenFinex side
 pub trait PolkaDexGatewayCallback {
     fn process_cancel_order(&self, order_uuid: OrderUUID) -> Result<(), GatewayError>;
@@ -815,7 +806,7 @@ pub fn get_price(
     price.ok_or(GatewayError::PriceIsNull)
 }
 
-#[derive(Eq, Debug, PartialOrd, PartialEq)]
+#[derive(Debug, Display, From, PartialEq, Eq)]
 pub enum GatewayError {
     /// Price is Not Provided
     PriceIsNull,

--- a/enclave/src/test_polkadex_gateway.rs
+++ b/enclave/src/test_polkadex_gateway.rs
@@ -83,7 +83,7 @@ pub fn initialize_storage() {
     // Initialize Gateway
     initialize_polkadex_gateway();
     // Initialize Account Storage
-    assert!(create_in_memory_accounts_and_nonce_storage(vec![]).is_ok());
+    create_in_memory_accounts_and_nonce_storage(vec![]);
     // Initialize Balance storage
     assert!(create_in_memory_balance_storage().is_ok());
     // Initialize Order Mirror

--- a/stf/src/commands/cancel_order.rs
+++ b/stf/src/commands/cancel_order.rs
@@ -83,7 +83,7 @@ fn command_runner<'a>(
 
     let _ = perform_operation(matches, &cancel_order_top);
 
-    debug!("cancel_order trusted operation was executed");
+    println!("Succesfully issues cancel order request");
 
     Ok(())
 }

--- a/stf/src/commands/cancel_order.rs
+++ b/stf/src/commands/cancel_order.rs
@@ -81,10 +81,10 @@ fn command_runner<'a>(
 
     debug!("Successfully built cancel_order trusted operation, dispatching now to enclave");
 
-    let _ = perform_operation(matches, &cancel_order_top);
-
-    println!("Succesfully issues cancel order request");
-
+    if let Some(_return_value) = perform_operation(matches, &cancel_order_top) {
+        // only print success if no error (= None returned) happened
+        println!("Succesfully issues cancel order request");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
- summarizes accout and nonce registry erros to one enum
- fixes rpc error return values to not be always "nonce uninitialized"
- fixes outdated python script cancel-order request
- client now prints success message if cancel_order does not return an error

Output now looks like the following:

```zsh
./substratee-client -p 9994 -P 2094 trusted cancel_order --accountid=//Alice --orderid=oijef03jaf --marketbase=btc --marketquote=usd --mrenclave=9DEggF3cbcuumAjsanchCnsbVjTURqkmUP1PekSWuv7x --direct
[Error] RPC call failed: Authorization error: AccountNotRegistered

./substratee-client -p 9994 -P 2094 register-account //Alice
[+] Transaction got finalized.. Hash: 0x3b5350dc1af8d821e28c4a8d30055985932d3b7daceab273e1631f2878d4856e

 ./substratee-client -p 9994 -P 2094 trusted cancel_order --accountid=//Alice --orderid=oijef03jaf --marketbase=btc --marketquote=usd --mrenclave=9DEggF3cbcuumAjsanchCnsbVjTURqkmUP1PekSWuv7x --direct
[Error] RPC call failed: OpenfinexWebSocketError("\"Failed to send request\"")
```


(interpretation: cancel_order gets through until openfinex client, hence fixing issue #270)