### PR TITLE
Edit Order RPC

### DIFF
--- a/enclave/src/polkadex_orderbook_storage.rs
+++ b/enclave/src/polkadex_orderbook_storage.rs
@@ -153,6 +153,16 @@ pub fn lock_storage_and_add_order(
     Ok(orderbook.add_order(order_uuid, order))
 }
 
+pub fn lock_storage_and_read_order(order_uuid: OrderUUID) -> Result<Order, GatewayError> {
+    let mutex = load_orderbook()?;
+    // TODO: Handle this unwrap
+    let orderbook: SgxMutexGuard<OrderbookStorage> = mutex.lock().unwrap();
+    Ok(orderbook
+        .read_order(&order_uuid)
+        .ok_or(GatewayError::OrderNotFound)?
+        .clone())
+}
+
 // pub fn lock_storage_and_check_order_in_orderbook(
 //     order_uuid: OrderUUID,
 // ) -> Result<bool, GatewayError> {

--- a/enclave/src/polkadex_orderbook_storage.rs
+++ b/enclave/src/polkadex_orderbook_storage.rs
@@ -156,7 +156,8 @@ pub fn lock_storage_and_add_order(
 pub fn lock_storage_and_read_order(order_uuid: OrderUUID) -> Result<Order, GatewayError> {
     let mutex = load_orderbook()?;
     // TODO: Handle this unwrap
-    let orderbook: SgxMutexGuard<OrderbookStorage> = mutex.lock().unwrap();
+    let orderbook: SgxMutexGuard<OrderbookStorage> =
+        mutex.lock().map_err(|_| GatewayError::UnableToLock)?;
     Ok(orderbook
         .read_order(&order_uuid)
         .ok_or(GatewayError::OrderNotFound)?

--- a/enclave/src/rpc.rs
+++ b/enclave/src/rpc.rs
@@ -30,6 +30,7 @@ pub mod rpc_info;
 
 pub mod polkadex_rpc_gateway;
 pub mod rpc_cancel_order;
+pub mod rpc_edit_order;
 pub mod rpc_get_balance;
 pub mod rpc_nonce;
 pub mod rpc_place_order;

--- a/enclave/src/rpc/mocks/dummy_builder.rs
+++ b/enclave/src/rpc/mocks/dummy_builder.rs
@@ -19,7 +19,8 @@
 use crate::ShardIdentifier;
 use codec::Encode;
 use polkadex_sgx_primitives::types::{
-    CancelOrder, DirectRequest, MarketId, Order, OrderSide, OrderType, OrderUUID,
+    CancelOrder, DirectRequest, EditOrder, EditOrderInput, MarketId, Order, OrderSide, OrderType,
+    OrderUUID,
 };
 use polkadex_sgx_primitives::{AccountId, AssetId};
 use sp_core::{ed25519 as ed25519_core, Pair, H256};
@@ -59,6 +60,16 @@ pub fn create_dummy_cancel_order(account: AccountId, order_id: OrderUUID) -> Can
             base: AssetId::POLKADEX,
         },
         order_id,
+    }
+}
+
+pub fn create_dummy_edit_order(order_id: OrderUUID) -> EditOrder {
+    EditOrder {
+        order_id,
+        value: EditOrderInput {
+            price: Some(100),
+            quantity: 200,
+        },
     }
 }
 

--- a/enclave/src/rpc/mocks/rpc_gateway_mock.rs
+++ b/enclave/src/rpc/mocks/rpc_gateway_mock.rs
@@ -34,6 +34,7 @@ pub struct RpcGatewayMock {
     pub do_authorize: bool,
     pub balance_to_return: Option<Balances>,
     pub order_uuid: Option<OrderUUID>,
+    pub order: Option<Order>,
     pub nonce: u32,
 }
 
@@ -44,6 +45,7 @@ impl RpcGatewayMock {
             do_authorize: false,
             balance_to_return: None,
             order_uuid: None,
+            order: None,
             nonce: 0u32,
         }
     }
@@ -67,6 +69,18 @@ impl RpcGatewayMock {
         get_place_order_mock.order_uuid = order_uuid;
         get_place_order_mock.do_authorize = do_authorize;
         get_place_order_mock
+    }
+
+    pub fn mock_edit_order(
+        order_uuid: Option<OrderUUID>,
+        order: Option<Order>,
+        do_authorize: bool,
+    ) -> Self {
+        let mut get_edit_order_mock = RpcGatewayMock::default();
+        get_edit_order_mock.order_uuid = order_uuid;
+        get_edit_order_mock.order = order;
+        get_edit_order_mock.do_authorize = do_authorize;
+        get_edit_order_mock
     }
 
     pub fn mock_withdraw(do_authorize: bool) -> Self {

--- a/enclave/src/rpc/rpc_edit_order.rs
+++ b/enclave/src/rpc/rpc_edit_order.rs
@@ -1,0 +1,193 @@
+// This file is part of Polkadex.
+
+// Copyright (C) 2020-2021 Polkadex oü and Supercomputing Systems AG
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+pub extern crate alloc;
+use alloc::{boxed::Box, string::String, string::ToString};
+
+use crate::polkadex_cache::cache_api::RequestId;
+use crate::rpc::polkadex_rpc_gateway::RpcGateway;
+use crate::rpc::rpc_call_encoder::{JsonRpcCallEncoder, RpcCall, RpcCallEncoder};
+use crate::rpc::rpc_info::RpcCallStatus;
+use crate::rpc::trusted_operation_verifier::TrustedOperationExtractor;
+use codec::Encode;
+use jsonrpc_core::{BoxFuture, Params, Result as RpcResult, RpcMethodSync, Value};
+use log::*;
+use polkadex_sgx_primitives::types::{CancelOrder, DirectRequest};
+use sp_application_crypto::Pair;
+use substratee_stf::TrustedCall;
+use substratee_worker_primitives::DirectRequestStatus;
+
+pub struct RpcEditOrder {
+    top_extractor: Box<dyn TrustedOperationExtractor + 'static>,
+    rpc_gateway: Box<dyn RpcGateway + 'static>,
+}
+
+impl RpcEditOrder {
+    pub fn new(
+        top_extractor: Box<dyn TrustedOperationExtractor + 'static>,
+        rpc_gateway: Box<dyn RpcGateway + 'static>,
+    ) -> Self {
+        RpcEditOrder {
+            top_extractor,
+            rpc_gateway,
+        }
+    }
+
+    fn method_impl(
+        &self,
+        request: DirectRequest,
+        test: bool,
+    ) -> Result<(RequestId, bool, DirectRequestStatus), String> {
+        debug!("entering edit_order RPC");
+
+        let verified_trusted_operation =
+            self.top_extractor.get_verified_trusted_operation(request)?;
+
+        let trusted_call = self
+            .rpc_gateway
+            .authorize_trusted_call(verified_trusted_operation)?;
+
+        let main_account = trusted_call.main_account().clone();
+        let proxy_account = trusted_call.proxy_account();
+
+        let edit_order = match trusted_call {
+            TrustedCall::edit_order(_, edit_order, _) => Ok(edit_order),
+            _ => Err(RpcCallStatus::operation_type_mismatch.to_string()),
+        }?;
+
+        let edited_order = if test {
+            if edit_order.order_id.clone() != "lojoif93j2lngfa".encode() {
+                return Err(String::from("Failed to retrieve order from orderbook"));
+            } else {
+                crate::rpc::mocks::dummy_builder::create_dummy_order(
+                    crate::rpc::mocks::dummy_builder::create_dummy_account()
+                        .public()
+                        .into(),
+                )
+                .edit(edit_order.value)
+            }
+        } else {
+            crate::polkadex_orderbook_storage::lock_storage_and_read_order(
+                edit_order.order_id.clone(),
+            )
+            .map_err(|_| String::from("Failed to retrieve order from orderbook"))?
+            .edit(edit_order.value)
+        };
+
+        self.rpc_gateway
+            .cancel_order(
+                main_account.clone(),
+                proxy_account.clone(),
+                CancelOrder::from_order(edited_order.clone(), edit_order.order_id),
+            )
+            .map_err(|_| String::from("Failed to cancel order"))?;
+
+        let result = match self
+            .rpc_gateway
+            .place_order(main_account, proxy_account, edited_order)
+        {
+            Ok(request_id) => Ok(request_id),
+            Err(e) => Err(e.to_string()),
+        }?;
+
+        Ok((result, true, DirectRequestStatus::Ok))
+    }
+}
+
+impl RpcCall for RpcEditOrder {
+    fn name() -> String {
+        "edit_order".to_string()
+    }
+}
+
+impl RpcMethodSync for RpcEditOrder {
+    fn call(&self, params: Params) -> BoxFuture<RpcResult<Value>> {
+        JsonRpcCallEncoder::call(params, &|r: DirectRequest| self.method_impl(r, false))
+    }
+}
+
+pub mod tests {
+
+    use super::*;
+    use crate::rpc::mocks::dummy_builder::{
+        create_dummy_account, create_dummy_edit_order, create_dummy_order, create_dummy_request,
+        sign_trusted_call,
+    };
+    use crate::rpc::mocks::rpc_gateway_mock::RpcGatewayMock;
+    use crate::rpc::mocks::trusted_operation_extractor_mock::TrustedOperationExtractorMock;
+    use codec::Encode;
+    use polkadex_sgx_primitives::types::OrderUUID;
+    use polkadex_sgx_primitives::AccountId;
+    use sp_core::Pair;
+    use substratee_stf::TrustedOperation;
+
+    pub fn test_given_valid_order_id_return_success() {
+        let order_id = "lojoif93j2lngfa".encode();
+
+        let top_extractor = Box::new(TrustedOperationExtractorMock {
+            trusted_operation: Some(create_edit_order_operation(order_id.clone())),
+        });
+
+        let rpc_gateway = Box::new(RpcGatewayMock::mock_edit_order(
+            Some(order_id),
+            Some(create_dummy_order(create_dummy_account().public().into())),
+            true,
+        ));
+
+        let request = create_dummy_request();
+
+        let rpc_edit_order = RpcEditOrder::new(top_extractor, rpc_gateway);
+
+        let result = rpc_edit_order.method_impl(request, true).unwrap();
+
+        assert_eq!(result.2, DirectRequestStatus::Ok);
+    }
+
+    pub fn test_given_order_id_mismatch_then_fail() {
+        let order_id = "lojoif93j2lngfa".encode();
+
+        let top_extractor = Box::new(TrustedOperationExtractorMock {
+            trusted_operation: Some(create_edit_order_operation(order_id)),
+        });
+
+        let rpc_gateway = Box::new(RpcGatewayMock::mock_edit_order(
+            Some("other_id_that_doesnt_match".encode()),
+            Some(create_dummy_order(create_dummy_account().public().into())),
+            true,
+        ));
+
+        let request = create_dummy_request();
+
+        let rpc_edit_order = RpcEditOrder::new(top_extractor, rpc_gateway);
+
+        let result = rpc_edit_order.method_impl(request, true);
+
+        assert!(result.is_err());
+    }
+
+    fn create_edit_order_operation(order_id: OrderUUID) -> TrustedOperation {
+        let key_pair = create_dummy_account();
+        let account_id: AccountId = key_pair.public().into();
+        let edit_order = create_dummy_edit_order(order_id);
+
+        let trusted_call = TrustedCall::edit_order(account_id, edit_order, None);
+        let trusted_call_signed = sign_trusted_call(trusted_call, key_pair, 0u32);
+
+        TrustedOperation::direct_call(trusted_call_signed)
+    }
+}

--- a/enclave/src/tests.rs
+++ b/enclave/src/tests.rs
@@ -73,7 +73,7 @@ use rpc::author::{Author, AuthorApi};
 use rpc::{api::SideChainApi, basic_pool::BasicPool};
 use rpc::{
     io_handler_extensions, polkadex_rpc_gateway, rpc_call_encoder, rpc_cancel_order,
-    rpc_get_balance, rpc_withdraw, trusted_operation_verifier,
+    rpc_edit_order, rpc_get_balance, rpc_withdraw, trusted_operation_verifier,
 };
 
 #[no_mangle]
@@ -180,6 +180,8 @@ pub extern "C" fn test_main_entrance() -> size_t {
         //rpc_place_order::tests::test_given_valid_call_return_order_uuid, TODO: @Bigna this test case is failing ... I need your help with this
         rpc_cancel_order::tests::test_given_valid_order_id_return_success,
         rpc_cancel_order::tests::test_given_order_id_mismatch_then_fail,
+        rpc_edit_order::tests::test_given_valid_order_id_return_success,
+        rpc_edit_order::tests::test_given_order_id_mismatch_then_fail,
         rpc_withdraw::tests::test_given_valid_call_then_succeed,
         rpc_withdraw::tests::test_given_unauthorized_access_then_return_error,
         trusted_operation_verifier::tests::given_valid_operation_in_request_then_decode_succeeds,

--- a/polkadex-primitives/src/types.rs
+++ b/polkadex-primitives/src/types.rs
@@ -178,6 +178,38 @@ pub struct CancelOrder {
     pub order_id: OrderUUID,
 }
 
+impl CancelOrder {
+    pub fn from_order(order: Order, order_id: OrderUUID) -> Self {
+        CancelOrder {
+            user_uid: order.user_uid,
+            market_id: order.market_id,
+            order_id,
+        }
+    }
+}
+
+// Edit Order
+#[derive(Debug, Clone, Encode, Decode, PartialEq)]
+pub struct EditOrder {
+    pub order_id: OrderUUID,
+    pub value: EditOrderInput,
+}
+
+#[derive(Debug, Clone, Encode, Decode, PartialEq)]
+pub struct EditOrderInput {
+    pub price: Option<PriceAndQuantityType>,
+    pub quantity: PriceAndQuantityType,
+}
+
+impl Order {
+    pub fn edit(&self, edit_order_input: EditOrderInput) -> Self {
+        let mut edited = self.clone();
+        edited.price = edit_order_input.price;
+        edited.quantity = edit_order_input.quantity;
+        edited
+    }
+}
+
 // Deposit Funds
 #[derive(Debug, Clone, Encode, Decode, PartialEq)]
 pub struct DepositFund {

--- a/stf/src/sgx.rs
+++ b/stf/src/sgx.rs
@@ -395,6 +395,7 @@ impl Stf {
             TrustedCall::balance_shield(_, _) => debug!("No storage updates needed..."),
             TrustedCall::place_order(_, _, _) => debug!("No storage updates needed..."),
             TrustedCall::cancel_order(_, _, _) => debug!("No storage updates needed..."),
+            TrustedCall::edit_order(_, _, _) => debug!("No storage updates needed..."),
             TrustedCall::withdraw(_, _, _, _) => debug!("No storage updates needed..."),
         };
         key_hashes


### PR DESCRIPTION
This PR implements the Edit Order RPC endpoint by means of removing the order and replacing the edited version. Closes #259 